### PR TITLE
packagekit: allow system-sources-refresh w/o password entry (bsc#1169…

### DIFF
--- a/profiles/polkit-default-privs.restrictive
+++ b/profiles/polkit-default-privs.restrictive
@@ -73,7 +73,7 @@ org.freedesktop.packagekit.package-remove                       auth_admin_keep_
 org.freedesktop.packagekit.system-update                        auth_admin_keep_always
 org.freedesktop.packagekit.system-rollback                      auth_admin_keep_always
 org.freedesktop.packagekit.system-sources-configure             auth_admin_keep_always
-org.freedesktop.packagekit.system-sources-refresh               auth_admin_keep_always
+org.freedesktop.packagekit.system-sources-refresh               auth_admin:auth_admin_keep_always:yes
 org.freedesktop.packagekit.system-network-proxy-configure       auth_admin_keep_always
 org.freedesktop.packagekit.cancel-foreign                       auth_admin_keep
 org.freedesktop.packagekit.device-rebind                        auth_admin_keep


### PR DESCRIPTION
…540)

The restrictive profile is the default setting on SLE. There usability
suffers from this, because after each login an auth prompt is popping
up. This solution is not ideal but we need to fix the usability in the
short term.