### PR TITLE
restrictive profile: allow local users to reboot/shutdown (bsc#1171115)

### DIFF
--- a/profiles/polkit-default-privs.restrictive
+++ b/profiles/polkit-default-privs.restrictive
@@ -351,9 +351,9 @@ org.freedesktop.timedate1.set-local-rtc                         auth_admin_keep
 org.freedesktop.locale1.set-locale                              auth_admin_keep
 org.freedesktop.login1.attach-device                            auth_admin_keep
 org.freedesktop.login1.flush-devices                            auth_admin_keep
-org.freedesktop.login1.power-off                                auth_admin_keep
+org.freedesktop.login1.power-off                                auth_admin_keep:auth_admin_keep:yes
 org.freedesktop.login1.power-off-multiple-sessions              auth_admin_keep
-org.freedesktop.login1.reboot                                   auth_admin_keep
+org.freedesktop.login1.reboot                                   auth_admin_keep:auth_admin_keep:yes
 org.freedesktop.login1.reboot-multiple-sessions                 auth_admin_keep
 org.freedesktop.login1.set-user-linger                          auth_admin_keep
 org.freedesktop.login1.set-self-linger                          yes


### PR DESCRIPTION
There are many other ways to reboot or shutdown a system e.g. via the
display manager or the text login console, power button etc. To really
restrict this (e.g. for kiosk systems) a system integrator would need to
apply a lot of configuration adjustment to prevent local users to
perform these actions.

Also these settings are now in line with "login1.hibernate" and
"login1.suspend" which are already allowed for local sessions.