### PR TITLE
libvirt: allow the active session to create read-only connections (bs…

### DIFF
--- a/profiles/polkit-default-privs.restrictive
+++ b/profiles/polkit-default-privs.restrictive
@@ -557,7 +557,7 @@ org.kde.powerdevil.backlighthelper.syspath 			no:yes:yes
 
 #
 #
-org.libvirt.unix.monitor                                    	auth_admin_keep_always
+org.libvirt.unix.monitor                                    	auth_admin:auth_admin_keep_always:yes
 org.libvirt.unix.manage                                     	auth_admin_keep_always
 
 # libvirt (bnc#827644) ( original wants yes:yes:yes)


### PR DESCRIPTION
…c#1179126)

via polkit rules members of the group libvirt are allowed to create
read-write connections to libvirt without authentication. read-only
conenctions are still restricted to root, however. This is inconsistent.

By allowing the active session to access the read-only socket without
password also in the restrictive profile this should be mitigated.