### PR TITLE
profiles: add kdenetwork-filesharing (bsc#1175633)

### DIFF
--- a/profiles/polkit-default-privs.easy
+++ b/profiles/polkit-default-privs.easy
@@ -697,3 +697,8 @@ com.endlessm.ParentalControls.SessionLimits.ChangeOwn           auth_admin_keep:
 com.endlessm.ParentalControls.SessionLimits.ReadAny             auth_admin_keep:auth_admin_keep:auth_admin_keep
 org.freedesktop.MalcontentControl.administration                no:no:auth_admin_keep
 com.endlessm.ParentalControls.AccountInfo.ReadOwn               yes:yes:yes
+
+# kdenetwork-filesharing, Samba configuration (bsc#1175633)
+org.kde.filesharing.samba.isuserknown                           yes:yes:yes
+org.kde.filesharing.samba.createuser                            auth_admin:auth_admin:auth_admin
+org.kde.filesharing.samba.addtogroup                            auth_admin:auth_admin:auth_admin

--- a/profiles/polkit-default-privs.restrictive
+++ b/profiles/polkit-default-privs.restrictive
@@ -697,3 +697,8 @@ com.endlessm.ParentalControls.SessionLimits.ChangeOwn           no:auth_admin:au
 com.endlessm.ParentalControls.SessionLimits.ReadAny             no:auth_admin:auth_admin_keep
 org.freedesktop.MalcontentControl.administration                no:no:auth_admin
 com.endlessm.ParentalControls.AccountInfo.ReadOwn               auth_admin:auth_admin:yes
+
+# kdenetwork-filesharing, Samba configuration (bsc#1175633)
+org.kde.filesharing.samba.isuserknown                           auth_admin_keep:auth_admin_keep:auth_admin_keep
+org.kde.filesharing.samba.createuser                            auth_admin:auth_admin:auth_admin
+org.kde.filesharing.samba.addtogroup                            auth_admin:auth_admin:auth_admin

--- a/profiles/polkit-default-privs.standard
+++ b/profiles/polkit-default-privs.standard
@@ -697,3 +697,8 @@ com.endlessm.ParentalControls.SessionLimits.ChangeOwn           auth_admin_keep:
 com.endlessm.ParentalControls.SessionLimits.ReadAny             auth_admin_keep:auth_admin_keep:auth_admin_keep
 org.freedesktop.MalcontentControl.administration                no:no:auth_admin_keep
 com.endlessm.ParentalControls.AccountInfo.ReadOwn               yes:yes:yes
+
+# kdenetwork-filesharing, Samba configuration (bsc#1175633)
+org.kde.filesharing.samba.isuserknown                           yes:yes:yes
+org.kde.filesharing.samba.createuser                            auth_admin:auth_admin:auth_admin
+org.kde.filesharing.samba.addtogroup                            auth_admin:auth_admin:auth_admin


### PR DESCRIPTION
The necessary changes to fix the issues found in [bsc#1175633](https://bugzilla.suse.com/show_bug.cgi?id=1175633) (AUDIT-TRACKER: kdenetwork-filesharing) are [fixed in OBS](https://build.opensuse.org/package/rdiff/KDE:Unstable:Applications/kdenetwork-filesharing?linkrev=base&rev=80).
