### PR TITLE
Switching from /etc to /usr/etc directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 DESTDIR=
 sbindir=/sbin
-sysconfdir=/etc
+sysconfdir=/usr/etc
 fillupdir=/var/adm/fillup-templates
 mandir=/usr/share/man
 docdir=/usr/share/doc/packages

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-polkit-default-privs
+polkit-default-privs 
 ====================
 
 This repository contains documentation, configuration and programs for

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-polkit-default-privs 
+polkit-default-privs
 ====================
 
 This repository contains documentation, configuration and programs for

--- a/man/polkit-default-privs.5
+++ b/man/polkit-default-privs.5
@@ -1,13 +1,13 @@
 '\" t
 .\"     Title: polkit-default-privs
 .\"    Author: [see the "AUTHORS" section]
-.\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
-.\"      Date: 02/07/2019
+.\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
+.\"      Date: 07/06/2021
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "POLKIT\-DEFAULT\-PRI" "5" "02/07/2019" "\ \&" "\ \&"
+.TH "POLKIT\-DEFAULT\-PRI" "5" "07/06/2021" "\ \&" "\ \&"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -31,7 +31,7 @@
 polkit-default-privs \- configuration of polkit security profiles
 .SH "DESCRIPTION"
 .sp
-The files \fI/etc/polkit\-default\-privs\&.*\fR define different security profiles that influence the authorization required for various polkit actions used across applications\&. These files are line based and whitespace delimited\&.
+The files \fI/usr/etc/polkit\-default\-privs\&.*\fR define different security profiles that influence the authorization required for various polkit actions used across applications\&. These files are line based and whitespace delimited\&.
 .sp
 Lines starting with # are comments\&. Comments and empty lines will be ignored\&. All other lines consist of two whitespace delimited columns \fIACTION\fR and \fIAUTHORIZATION\fR\&. The \fIACTION\fR column specifies the polkit action name to configure the default polkit authorization settings for\&.
 .sp
@@ -96,13 +96,15 @@ This line configures the org\&.spice\-space\&.lowlevelusbaccess polkit action to
 This line configures the net\&.connman\&.modify polkit action to require admin authentication for all three user context types: remote users, inactive users and active users\&.
 .SH "FILES"
 .sp
+/usr/etc/polkit\-default\-privs\&.local is a template for:
+.sp
 /etc/polkit\-default\-privs\&.local
 .sp
-/etc/polkit\-default\-privs\&.restrictive
+/usr/etc/polkit\-default\-privs\&.restrictive
 .sp
-/etc/polkit\-default\-privs\&.standard
+/usr/etc/polkit\-default\-privs\&.standard
 .sp
-/etc/polkit\-default\-privs\&.easy
+/usr/etc/polkit\-default\-privs\&.easy
 .sp
 /etc/polkit\-default\-privs\&.d/*
 .SH "SEE ALSO"

--- a/man/polkit-default-privs.adoc
+++ b/man/polkit-default-privs.adoc
@@ -7,7 +7,7 @@ polkit-default-privs - configuration of polkit security profiles
 
 DESCRIPTION
 -----------
-The files _/etc/polkit-default-privs.*_ define different security profiles
+The files _/usr/etc/polkit-default-privs.*_ define different security profiles
 that influence the authorization required for various polkit actions used
 across applications. These files are line based and whitespace delimited.
 
@@ -77,13 +77,15 @@ and active users.
 FILES
 -----
 
+`/usr/etc/polkit-default-privs.local` is a template for:
+
 `/etc/polkit-default-privs.local`
 
-`/etc/polkit-default-privs.restrictive`
+`/usr/etc/polkit-default-privs.restrictive`
 
-`/etc/polkit-default-privs.standard`
+`/usr/etc/polkit-default-privs.standard`
 
-`/etc/polkit-default-privs.easy`
+`/usr/etc/polkit-default-privs.easy`
 
 `/etc/polkit-default-privs.d/*`
 

--- a/profiles/polkit-default-privs.easy
+++ b/profiles/polkit-default-privs.easy
@@ -1,9 +1,10 @@
 #
-# /etc/polkit-default-privs.easy is set up for use in single-user
+# /usr/etc/polkit-default-privs.easy is set up for use in single-user
 # desktop systems to make common operations work out-of-the box for
 # locally logged in users.
 #
-# Please do not modify this file, use polkit-default-privs.local instead.
+# Please do not modify this file, use a local copy of
+# /usr/etc/polkit-default-privs.local in /etc instead.
 
 
 # NetworkManager

--- a/profiles/polkit-default-privs.local
+++ b/profiles/polkit-default-privs.local
@@ -1,5 +1,7 @@
 #
 # /etc/polkit-default-privs.local
+# NOTE: This file is a template ONLY. Please create a copy of it in the
+#       /etc directory and remove this line.
 #
 # This file is used by the set_polkit_default_privs tool to generate polkit
 # rules. It is meant for local overrides of the active profile (defined in

--- a/profiles/polkit-default-privs.restrictive
+++ b/profiles/polkit-default-privs.restrictive
@@ -1,10 +1,11 @@
 #
-# /etc/polkit-default-privs.restrictive use in an environment where
+# /usr/etc/polkit-default-privs.restrictive use in an environment where
 # security is a major concern or hosts are centrally administered and users
 # should have minimal privileges. Many operations require authentication
 # as admin.
 #
-# Please do not modify this file, use polkit-default-privs.local instead.
+# Please do not modify this file, use a local copy of
+# /usr/etc/polkit-default-privs.local in /etc instead.
 
 # NetworkManager
 org.freedesktop.NetworkManager.enable-disable-network           no:no:auth_admin

--- a/profiles/polkit-default-privs.standard
+++ b/profiles/polkit-default-privs.standard
@@ -1,10 +1,11 @@
 #
-# /etc/polkit-default-privs.standard is set up balanced use cases like
+# /usr/etc/polkit-default-privs.standard is set up balanced use cases like
 # multi-user desktop or server systems. It allows to make common operations
 # work out-of-the box for locally logged in users. It still restricts users
 # enough to be safely used on most multi user hosts.
 #
-# Please do not modify this file, use polkit-default-privs.local instead.
+# Please do not modify this file, use a local copy of
+# /usr/etc/polkit-default-privs.local/ in /etc instead.
 
 # NetworkManager
 org.freedesktop.NetworkManager.enable-disable-network           no:no:yes

--- a/src/set_polkit_default_privs
+++ b/src/set_polkit_default_privs
@@ -51,8 +51,8 @@ have_local=
 for level in $POLKIT_DEFAULT_PRIVS; do
     case "$level" in
 	easy|standard|restrictive)
-	    if [ -e /etc/polkit-default-privs.$level ]; then
-		files="$files /etc/polkit-default-privs.$level"
+	    if [ -e /usr/etc/polkit-default-privs.$level ]; then
+		files="$files /usr/etc/polkit-default-privs.$level"
 	    fi
 	;;
 	*)

--- a/tools/listpolicies.pl
+++ b/tools/listpolicies.pl
@@ -43,7 +43,7 @@ if ($#ARGV == -1) {
 	my $rpm_buildroot = $ENV{'RPM_BUILD_ROOT'} || '';
 	push @ARGV, glob "$rpm_buildroot/usr/share/polkit-1/actions/*.policy";
 	unless ($options{'policy'}) {
-		$options{'policy'} = [ "$buildroot/etc/polkit-default-privs.standard" ];
+		$options{'policy'} = [ "$buildroot/urs/etc/polkit-default-privs.standard" ];
 	}
 }
 


### PR DESCRIPTION
Moving polkit-default-privs.easy, polkit-default-privs.local and polkit-default-privs.restrictive from /etc /to /usr/etc directory.