### PR TITLE
kdenetwork-filesharing: align with upstream

### DIFF
--- a/profiles/polkit-default-privs.standard
+++ b/profiles/polkit-default-privs.standard
@@ -701,7 +701,7 @@ org.freedesktop.MalcontentControl.administration                no:no:auth_admin
 com.endlessm.ParentalControls.AccountInfo.ReadOwn               yes:yes:yes
 
 # kdenetwork-filesharing, Samba configuration (bsc#1175633)
-org.kde.filesharing.samba.isuserknown                           yes:yes:yes
+org.kde.filesharing.samba.isuserknown                           no:yes:yes
 org.kde.filesharing.samba.createuser                            auth_admin:auth_admin:auth_admin
 org.kde.filesharing.samba.addtogroup                            auth_admin:auth_admin:auth_admin
 


### PR DESCRIPTION
Our standard profile was less strict than upstream. 
> org.kde.filesharing.samba.isuserknown
> I: [polkit-action-origin] action is defined in policy /usr/share/polkit-1/actions/org.kde.filesharing.samba.policy shipped in rpm kdenetwork-filesharing-21.04.2-1.1.x86_64.rpm from package kdenetwork-filesharing
> W: [profile-auth-weaker-than-upstream] profile standard: setting yes:yes:yes is weaker than upstream setting no:yes:yes

The setting `yes:yes:yes` was chosen consciously because there is no obvious harm in letting unprivileged users test if a user name exists on the local system, IMHO. However there is no downside to conforming with upstream either.