### PR TITLE
fprint.device.enroll: keep restrictive profile in sync with upstream

### DIFF
--- a/profiles/polkit-default-privs.restrictive
+++ b/profiles/polkit-default-privs.restrictive
@@ -365,7 +365,7 @@ org.freedesktop.udisks2.power-off-drive                         auth_admin:auth_
 
 # fprintfd (bsc#792095, bsc#850807)
 net.reactivated.fprint.device.verify                            no:no:yes
-net.reactivated.fprint.device.enroll                            no:no:yes
+net.reactivated.fprint.device.enroll                            no:no:auth_self_keep
 net.reactivated.fprint.device.setusername                       no:no:auth_admin_keep
 
 # gnome-system-monitor (bsc#822011)


### PR DESCRIPTION
This was relaxed via commit 8c4cbc5, bsc#850807. The enroll action was a
bit unclear back than. Let's keep it in sync with upstream at least for
the restrictive profile.