### PR TITLE
50-default.rules: move to /usr (contents unchanged)

### DIFF
--- a/etc/polkit-rules-whitelist.json
+++ b/etc/polkit-rules-whitelist.json
@@ -14,7 +14,7 @@
 			"bsc#1125314": {
 				"comment": "default rule shipped by polkit, allows uid 0 to do everything",
 				"digests": {
-					"/etc/polkit-1/rules.d/50-default.rules": "sha256:aea3041de2c15db8683620de8533206e50241c309eb27893605d5ead17e5e75f"
+					"/usr/share/polkit-1/rules.d/50-default.rules": "sha256:aea3041de2c15db8683620de8533206e50241c309eb27893605d5ead17e5e75f"
 				}
 			}
 		}


### PR DESCRIPTION
`50-default.rules` is about to be moved to a new location. The contents remains unchanged.

Reference: https://build.opensuse.org/request/show/905083

> Wed Jul  7 08:15:04 UTC 2021 - Stefan Schubert <schubi@suse.com>
> 
> - Move /etc/polkit-1/rules.d/50-default.rules to /usr/share/polkit-1/rules.d/50-default.rules. The first location is only for admin changes.