### PR TITLE
kdenetwork-filesharing: tighten the restrictive profile

### DIFF
--- a/profiles/polkit-default-privs.restrictive
+++ b/profiles/polkit-default-privs.restrictive
@@ -700,7 +700,7 @@ org.freedesktop.MalcontentControl.administration                no:no:auth_admin
 com.endlessm.ParentalControls.AccountInfo.ReadOwn               auth_admin:auth_admin:yes
 
 # kdenetwork-filesharing, Samba configuration (bsc#1175633)
-org.kde.filesharing.samba.isuserknown                           auth_admin_keep:auth_admin_keep:auth_admin_keep
+org.kde.filesharing.samba.isuserknown                           no:auth_admin_keep:auth_admin_keep
 org.kde.filesharing.samba.createuser                            auth_admin:auth_admin:auth_admin
 org.kde.filesharing.samba.addtogroup                            auth_admin:auth_admin:auth_admin
 


### PR DESCRIPTION
The standard profile should not be more strict than the restrictive profile.

>org.kde.filesharing.samba.isuserknown
>I: [polkit-action-origin] action is defined in policy /usr/share/polkit-1/actions/org.kde.filesharing.samba.policy shipped in rpm kdenetwork-filesharing-21.04.3-1.1.x86_64.rpm from package kdenetwork-filesharing
>W: [profiles-inconsistent-auth-requirements] 'any' setting in profile standard has stronger auth type (no) than profile restrictive (auth_admin_keep)
>W: [profiles-inconsistent-auth-requirements] 'any' setting in profile standard has stronger auth type (no) than profile restrictive (auth_admin_keep)