### PR TITLE
whitelisting of GNOME malcontent parental controls (bsc#1177974)

### DIFF
--- a/etc/polkit-rules-whitelist.json
+++ b/etc/polkit-rules-whitelist.json
@@ -75,5 +75,16 @@
 				"digest": "sha256:6daefe0a835dc1b34513302f393e98089c137602823f41fd0c3dd984c40902d8"
 			}
 		]
+	},
+	{
+		"package": "malcontent",
+		"path": "/usr/share/polkit-1/rules.d/com.endlessm.ParentalControls.rules",
+		"audits": [
+			{
+				"bug": "bsc#1177974",
+				"comment": "Allows wheel members to bypass parental controls. We allow this as an exception (granting implicit authorization to wheel) since this is not security relevant per se.",
+				"digests": "sha256:4dca105e78ff95c2317386d4df4f959f0c055eec13e12c34c48084b9bbb385b4"
+			}
+		]
 	}
 ]

--- a/profiles/polkit-default-privs.easy
+++ b/profiles/polkit-default-privs.easy
@@ -1051,4 +1051,19 @@ com.github.calamares.calamares.pkexec.run no:no:auth_admin
 # incremental addition for DHCP forced renew (bsc#1176215)
 org.freedesktop.network1.forcerenew auth_admin:auth_admin:auth_admin_keep
 
+# GNOME parental controls, accountservice extensions (bsc#1177974)
+com.endlessm.ParentalControls.AccountInfo.ReadAny yes:yes:yes
+com.endlessm.ParentalControls.AppFilter.ReadOwn yes:yes:yes
+com.endlessm.ParentalControls.SessionLimits.ReadOwn yes:yes:yes
+com.endlessm.ParentalControls.AccountInfo.ChangeAny auth_admin_keep:auth_admin_keep:auth_admin_keep
+com.endlessm.ParentalControls.AccountInfo.ChangeOwn auth_admin_keep:auth_admin_keep:auth_admin_keep
+com.endlessm.ParentalControls.AppFilter.ChangeAny auth_admin_keep:auth_admin_keep:auth_admin_keep
+com.endlessm.ParentalControls.AppFilter.ChangeOwn auth_admin_keep:auth_admin_keep:auth_admin_keep
+com.endlessm.ParentalControls.AppFilter.ReadAny auth_admin_keep:auth_admin_keep:auth_admin_keep
+com.endlessm.ParentalControls.SessionLimits.ChangeAny auth_admin_keep:auth_admin_keep:auth_admin_keep
+com.endlessm.ParentalControls.SessionLimits.ChangeOwn auth_admin_keep:auth_admin_keep:auth_admin_keep
+com.endlessm.ParentalControls.SessionLimits.ReadAny auth_admin_keep:auth_admin_keep:auth_admin_keep
+org.freedesktop.MalcontentControl.administration no:no:auth_admin_keep
+com.endlessm.ParentalControls.AccountInfo.ReadOwn yes:yes:yes
+
 ###

--- a/profiles/polkit-default-privs.restrictive
+++ b/profiles/polkit-default-privs.restrictive
@@ -989,4 +989,19 @@ com.github.calamares.calamares.pkexec.run no:no:auth_admin
 # incremental addition for DHCP forced renew (bsc#1176215)
 org.freedesktop.network1.forcerenew auth_admin:auth_admin:auth_admin_keep
 
+# GNOME parental controls, accountservice extensions (bsc#1177974)
+com.endlessm.ParentalControls.AccountInfo.ReadAny auth_admin:auth_admin:yes
+com.endlessm.ParentalControls.AppFilter.ReadOwn auth_admin:auth_admin:yes
+com.endlessm.ParentalControls.SessionLimits.ReadOwn auth_admin:auth_admin:yes
+com.endlessm.ParentalControls.AccountInfo.ChangeAny no:auth_admin:auth_admin_keep
+com.endlessm.ParentalControls.AccountInfo.ChangeOwn no:auth_admin:auth_admin_keep
+com.endlessm.ParentalControls.AppFilter.ChangeAny no:auth_admin:auth_admin_keep
+com.endlessm.ParentalControls.AppFilter.ChangeOwn no:auth_admin:auth_admin_keep
+com.endlessm.ParentalControls.AppFilter.ReadAny no:auth_admin:auth_admin_keep
+com.endlessm.ParentalControls.SessionLimits.ChangeAny no:auth_admin:auth_admin_keep
+com.endlessm.ParentalControls.SessionLimits.ChangeOwn no:auth_admin:auth_admin_keep
+com.endlessm.ParentalControls.SessionLimits.ReadAny no:auth_admin:auth_admin_keep
+org.freedesktop.MalcontentControl.administration no:no:auth_admin
+com.endlessm.ParentalControls.AccountInfo.ReadOwn auth_admin:auth_admin:yes
+
 ###

--- a/profiles/polkit-default-privs.standard
+++ b/profiles/polkit-default-privs.standard
@@ -1052,4 +1052,19 @@ com.github.calamares.calamares.pkexec.run no:no:auth_admin
 # incremental addition for DHCP forced renew (bsc#1176215)
 org.freedesktop.network1.forcerenew auth_admin:auth_admin:auth_admin_keep
 
+# GNOME parental controls, accountservice extensions (bsc#1177974)
+com.endlessm.ParentalControls.AccountInfo.ReadAny yes:yes:yes
+com.endlessm.ParentalControls.AppFilter.ReadOwn yes:yes:yes
+com.endlessm.ParentalControls.SessionLimits.ReadOwn yes:yes:yes
+com.endlessm.ParentalControls.AccountInfo.ChangeAny auth_admin_keep:auth_admin_keep:auth_admin_keep
+com.endlessm.ParentalControls.AccountInfo.ChangeOwn auth_admin_keep:auth_admin_keep:auth_admin_keep
+com.endlessm.ParentalControls.AppFilter.ChangeAny auth_admin_keep:auth_admin_keep:auth_admin_keep
+com.endlessm.ParentalControls.AppFilter.ChangeOwn auth_admin_keep:auth_admin_keep:auth_admin_keep
+com.endlessm.ParentalControls.AppFilter.ReadAny auth_admin_keep:auth_admin_keep:auth_admin_keep
+com.endlessm.ParentalControls.SessionLimits.ChangeAny auth_admin_keep:auth_admin_keep:auth_admin_keep
+com.endlessm.ParentalControls.SessionLimits.ChangeOwn auth_admin_keep:auth_admin_keep:auth_admin_keep
+com.endlessm.ParentalControls.SessionLimits.ReadAny auth_admin_keep:auth_admin_keep:auth_admin_keep
+org.freedesktop.MalcontentControl.administration no:no:auth_admin_keep
+com.endlessm.ParentalControls.AccountInfo.ReadOwn yes:yes:yes
+
 ###


### PR DESCRIPTION
The format of etc/polkit-rules-whitelist.json changed on the master branch and it is unclear if we will need to migrate to the new format (this will only become necessary if rpmlint-checks from Factory are also backported). Leaving the old format for the moment.