### PR TITLE
malcontent: loosen restrictive ReadOwn actions to prevent spurious au…

### DIFF
--- a/profiles/restrictive
+++ b/profiles/restrictive
@@ -690,8 +690,8 @@ io.veyon.pkexec.veyon-configurator                              no:no:auth_admin
 
 # GNOME parental controls, accountservice extensions (bsc#1177974)
 com.endlessm.ParentalControls.AccountInfo.ReadAny               auth_admin:auth_admin:yes
-com.endlessm.ParentalControls.AppFilter.ReadOwn                 auth_admin:auth_admin:yes
-com.endlessm.ParentalControls.SessionLimits.ReadOwn             auth_admin:auth_admin:yes
+com.endlessm.ParentalControls.AppFilter.ReadOwn                 yes:yes:yes
+com.endlessm.ParentalControls.SessionLimits.ReadOwn             yes:yes:yes
 com.endlessm.ParentalControls.AccountInfo.ChangeAny             no:auth_admin:auth_admin_keep
 com.endlessm.ParentalControls.AccountInfo.ChangeOwn             no:auth_admin:auth_admin_keep
 com.endlessm.ParentalControls.AppFilter.ChangeAny               no:auth_admin:auth_admin_keep
@@ -701,7 +701,7 @@ com.endlessm.ParentalControls.SessionLimits.ChangeAny           no:auth_admin:au
 com.endlessm.ParentalControls.SessionLimits.ChangeOwn           no:auth_admin:auth_admin_keep
 com.endlessm.ParentalControls.SessionLimits.ReadAny             no:auth_admin:auth_admin_keep
 org.freedesktop.MalcontentControl.administration                no:no:auth_admin
-com.endlessm.ParentalControls.AccountInfo.ReadOwn               auth_admin:auth_admin:yes
+com.endlessm.ParentalControls.AccountInfo.ReadOwn               yes:yes:yes
 
 # kdenetwork-filesharing, Samba configuration (bsc#1175633)
 org.kde.filesharing.samba.isuserknown                           no:auth_admin_keep:auth_admin_keep


### PR DESCRIPTION
…th requests

SLE-15-SP4 integration reports that having any/inactive set to
auth_admin for these actions causes auth popups when running via VNC or
when switching to other ttys. See bsc#1177974 comment#15.