### PR TITLE
malcontent: loosen restrictive ReadOwn actions to prevent spurious au…

### DIFF
--- a/profiles/polkit-default-privs.restrictive
+++ b/profiles/polkit-default-privs.restrictive
@@ -991,8 +991,8 @@ org.freedesktop.network1.forcerenew auth_admin:auth_admin:auth_admin_keep
 
 # GNOME parental controls, accountservice extensions (bsc#1177974)
 com.endlessm.ParentalControls.AccountInfo.ReadAny auth_admin:auth_admin:yes
-com.endlessm.ParentalControls.AppFilter.ReadOwn auth_admin:auth_admin:yes
-com.endlessm.ParentalControls.SessionLimits.ReadOwn auth_admin:auth_admin:yes
+com.endlessm.ParentalControls.AppFilter.ReadOwn                 yes:yes:yes
+com.endlessm.ParentalControls.SessionLimits.ReadOwn             yes:yes:yes
 com.endlessm.ParentalControls.AccountInfo.ChangeAny no:auth_admin:auth_admin_keep
 com.endlessm.ParentalControls.AccountInfo.ChangeOwn no:auth_admin:auth_admin_keep
 com.endlessm.ParentalControls.AppFilter.ChangeAny no:auth_admin:auth_admin_keep
@@ -1002,6 +1002,6 @@ com.endlessm.ParentalControls.SessionLimits.ChangeAny no:auth_admin:auth_admin_k
 com.endlessm.ParentalControls.SessionLimits.ChangeOwn no:auth_admin:auth_admin_keep
 com.endlessm.ParentalControls.SessionLimits.ReadAny no:auth_admin:auth_admin_keep
 org.freedesktop.MalcontentControl.administration no:no:auth_admin
-com.endlessm.ParentalControls.AccountInfo.ReadOwn auth_admin:auth_admin:yes
+com.endlessm.ParentalControls.AccountInfo.ReadOwn               yes:yes:yes
 
 ###


### PR DESCRIPTION
…th requests (#56)

SLE-15-SP4 integration reports that having any/inactive set to
auth_admin for these actions causes auth popups when running via VNC or
when switching to other ttys. See bsc#1177974 comment#15.