### PR TITLE
Backport KDE plasma5-disks (bsc#1195491)

### DIFF
--- a/profiles/polkit-default-privs.easy
+++ b/profiles/polkit-default-privs.easy
@@ -351,6 +351,9 @@ org.kde.kcontrol.kcmsddm.uninstalltheme                         no:no:auth_admin
 org.kde.kcontrol.kcmsddm.reset                                  no:no:auth_admin_keep
 org.kde.kcontrol.kcmsddm.sync                                   no:no:auth_admin_keep
 
+# KDE smartctl helper (bsc#1176742)
+org.kde.kded.smart.smartctl                                     auth_admin:auth_admin:yes
+
 # systemd (bnc#641924)
 org.freedesktop.hostname1.set-hostname                          auth_admin
 org.freedesktop.hostname1.set-static-hostname                   auth_admin

--- a/profiles/polkit-default-privs.restrictive
+++ b/profiles/polkit-default-privs.restrictive
@@ -770,6 +770,8 @@ org.kde.powerdevil.backlighthelper.brightness no:yes:yes
 org.kde.powerdevil.backlighthelper.brightnessmax no:yes:yes
 org.kde.powerdevil.backlighthelper.setbrightness no:no:yes
 
+# KDE smartctl helper (bsc#1176742)
+org.kde.kded.smart.smartctl                                     no:no:auth_admin
 
 # storaged (bnc#915770)
 com.redhat.lvm2.create-logical-volume		auth_admin_keep

--- a/profiles/polkit-default-privs.standard
+++ b/profiles/polkit-default-privs.standard
@@ -834,6 +834,8 @@ org.kde.powerdevil.backlighthelper.brightness no:yes:yes
 org.kde.powerdevil.backlighthelper.brightnessmax no:yes:yes
 org.kde.powerdevil.backlighthelper.setbrightness no:no:yes
 
+# KDE smartctl helper (bsc#1176742)
+org.kde.kded.smart.smartctl                                     no:auth_admin:yes
 
 # storaged (bnc#915770)
 com.redhat.lvm2.create-logical-volume		auth_admin_keep


### PR DESCRIPTION
This package has already been audited and whitelisted (bsc#1176742). While I was at it, I took the time and proofread the recent update from `plasma-disks-5.23.5` to `plasma-disks-5.23.90`. All changes are negligible and don't affect the privileged behavior. OK.