### PR TITLE
kpmcore: whitelist block device (re-)partioning helper (bsc#1178848)

### DIFF
--- a/profiles/easy
+++ b/profiles/easy
@@ -730,3 +730,6 @@ net.hadess.PowerProfiles.hold-profile auth_admin:yes:yes
 
 # kcron dbus helper (bsc#1193945)
 local.kcron.crontab.save no:no:auth_admin_keep
+
+# preliminary whitelisting of shaky partitioning service (bsc#1178848)
+org.kde.kpmcore.externalcommand.init no:no:auth_admin_keep

--- a/profiles/restrictive
+++ b/profiles/restrictive
@@ -731,3 +731,6 @@ net.hadess.PowerProfiles.hold-profile no:no:yes
 
 # kcron dbus helper (bsc#1193945)
 local.kcron.crontab.save no:no:auth_admin
+
+# preliminary whitelisting of shaky partitioning service (bsc#1178848)
+org.kde.kpmcore.externalcommand.init no:no:auth_admin

--- a/profiles/standard
+++ b/profiles/standard
@@ -732,3 +732,6 @@ net.hadess.PowerProfiles.hold-profile no:no:yes
 
 # kcron dbus helper (bsc#1193945)
 local.kcron.crontab.save no:no:auth_admin_keep
+
+# preliminary whitelisting of shaky partitioning service (bsc#1178848)
+org.kde.kpmcore.externalcommand.init no:no:auth_admin


### PR DESCRIPTION
The code is still a bit shaky (see bug) but the current kpmcore in
Factory is no longer building and requires running as root for the
complete application, so let's get ahead with this for at least some
security increase.