### PR TITLE
Fix generation of file /etc/polkit-1/rules.d/90-default-privs.rules

### DIFF
--- a/src/chkstat-polkit
+++ b/src/chkstat-polkit
@@ -111,7 +111,7 @@ polkit.addRule(function(action, subject) {
                 }
         }
 	if (debug)
-		polkit.log(subject);
+		polkit.log("subject=" + subject);
 
         if (rules[action.id]) {
 		if (debug)


### PR DESCRIPTION
When debug variable is set to true in file /etc/polkit-1/rules.d/90-default-privs.rules, if polkit daemon is running without the 
```--no-debug``` 
option, the process exits logging
```"Failed with result 'core-dump'."```

This is caused by the line
```javascript
polkit.log(subject);
```
that I suppose is not using subject as a String

Changing the line to
```javascript
polkit.log("subject=" + subject);
```
fixes the problem

I think that also other versions are affected