### PR TITLE
usbguard: relax read-only operations to yes

### DIFF
--- a/profiles/easy
+++ b/profiles/easy
@@ -735,9 +735,9 @@ local.kcron.crontab.save no:no:auth_admin_keep
 org.kde.kpmcore.externalcommand.init no:no:auth_admin_keep
 
 # D-Bus bridge connecting towards the custom IPC protocol of usbguard (bsc#1196621)
-org.usbguard.Policy1.listRules no:no:auth_self_keep
-org.usbguard.Devices1.listDevices no:no:auth_self_keep
-org.usbguard1.getParameter no:no:auth_self_keep
+org.usbguard.Policy1.listRules no:no:yes
+org.usbguard.Devices1.listDevices no:no:yes
+org.usbguard1.getParameter no:no:yes
 org.usbguard.Policy1.appendRule no:no:auth_admin_keep
 org.usbguard.Policy1.removeRule no:no:auth_admin_keep
 org.usbguard.Devices1.applyDevicePolicy no:no:auth_admin_keep

--- a/profiles/standard
+++ b/profiles/standard
@@ -737,9 +737,9 @@ local.kcron.crontab.save no:no:auth_admin_keep
 org.kde.kpmcore.externalcommand.init no:no:auth_admin
 
 # D-Bus bridge connecting towards the custom IPC protocol of usbguard (bsc#1196621)
-org.usbguard.Policy1.listRules no:no:auth_self_keep
-org.usbguard.Devices1.listDevices no:no:auth_self_keep
-org.usbguard1.getParameter no:no:auth_self_keep
+org.usbguard.Policy1.listRules no:no:yes
+org.usbguard.Devices1.listDevices no:no:yes
+org.usbguard1.getParameter no:no:yes
 org.usbguard.Policy1.appendRule no:no:auth_admin
 org.usbguard.Policy1.removeRule no:no:auth_admin
 org.usbguard.Devices1.applyDevicePolicy no:no:auth_admin


### PR DESCRIPTION
The auth_self_keep setting is unusual and not user friendly, offering
little benefits security wise. Upstream does not seem to have a special
reason for this:

https://github.com/USBGuard/usbguard/issues/544#issuecomment-1083103825

So let's relax these settings to 'yes' instead.