### PR TITLE
Backport of deepin-api whitelisting (bsc#1196681 bsc#1070943)

### DIFF
--- a/profiles/polkit-default-privs.easy
+++ b/profiles/polkit-default-privs.easy
@@ -1086,4 +1086,7 @@ local.kcron.crontab.save no:no:auth_admin_keep
 # preliminary whitelisting of shaky partitioning service (bsc#1178848)
 org.kde.kpmcore.externalcommand.init no:no:auth_admin_keep
 
+# deepin desktop environment helpers (bsc#1196681 bsc#1070943)
+com.deepin.api.device.unblock-bluetooth-devices no:no:auth_admin_keep
+
 ###

--- a/profiles/polkit-default-privs.restrictive
+++ b/profiles/polkit-default-privs.restrictive
@@ -1024,4 +1024,7 @@ local.kcron.crontab.save no:no:auth_admin
 # preliminary whitelisting of shaky partitioning service (bsc#1178848)
 org.kde.kpmcore.externalcommand.init no:no:auth_admin
 
+# deepin desktop environment helpers (bsc#1196681 bsc#1070943)
+com.deepin.api.device.unblock-bluetooth-devices no:no:auth_admin_keep
+
 ###

--- a/profiles/polkit-default-privs.standard
+++ b/profiles/polkit-default-privs.standard
@@ -1087,4 +1087,7 @@ local.kcron.crontab.save no:no:auth_admin_keep
 # preliminary whitelisting of shaky partitioning service (bsc#1178848)
 org.kde.kpmcore.externalcommand.init no:no:auth_admin
 
+# deepin desktop environment helpers (bsc#1196681 bsc#1070943)
+com.deepin.api.device.unblock-bluetooth-devices no:no:auth_admin_keep
+
 ###


### PR DESCRIPTION
LGTM. For completeness' sake I diffed the source of dde-api since the last proper audit, and there weren't any signifcant changes.