### PR TITLE
gconf: cleanup rules used by dropped gconf2 package

### DIFF
--- a/profiles/easy
+++ b/profiles/easy
@@ -74,10 +74,6 @@ org.freedesktop.packagekit.package-downgrade                    auth_admin:auth_
 # PackageKit (bsc#993505)
 org.freedesktop.packagekit.trigger-offline-upgrade              auth_admin:auth_admin:auth_admin
 
-# gconf
-org.gnome.gconf.defaults.set-system                             auth_admin_keep
-org.gnome.gconf.defaults.set-mandatory                          auth_admin_keep
-
 # system-config-printer
 org.opensuse.cupspkhelper.mechanism.printer-set-default         auth_admin_keep
 org.opensuse.cupspkhelper.mechanism.printer-enable              auth_admin_keep

--- a/profiles/restrictive
+++ b/profiles/restrictive
@@ -75,10 +75,6 @@ org.freedesktop.packagekit.package-downgrade                    auth_admin:auth_
 # PackageKit (bsc#993505)
 org.freedesktop.packagekit.trigger-offline-upgrade              no:auth_admin:auth_admin
 
-# gconf
-org.gnome.gconf.defaults.set-system                             auth_admin_keep
-org.gnome.gconf.defaults.set-mandatory                          auth_admin_keep
-
 # system-config-printer
 org.opensuse.cupspkhelper.mechanism.printer-set-default         auth_admin_keep
 org.opensuse.cupspkhelper.mechanism.printer-enable              auth_admin_keep

--- a/profiles/standard
+++ b/profiles/standard
@@ -75,10 +75,6 @@ org.freedesktop.packagekit.package-downgrade                    auth_admin:auth_
 # PackageKit (bsc#993505)
 org.freedesktop.packagekit.trigger-offline-upgrade              auth_admin:auth_admin:auth_admin
 
-# gconf
-org.gnome.gconf.defaults.set-system                             auth_admin_keep
-org.gnome.gconf.defaults.set-mandatory                          auth_admin_keep
-
 # system-config-printer
 org.opensuse.cupspkhelper.mechanism.printer-set-default         auth_admin_keep
 org.opensuse.cupspkhelper.mechanism.printer-enable              auth_admin_keep


### PR DESCRIPTION
gconf2 has recently been dropped from Factory via OBS sr#965379.

These actions are reported as no longer packaged by our checker scripts.
This report is correct. Therefore drop the now outdated entries.