### PR TITLE
Whitelist new systemd methods (bsc#1200098)

### DIFF
--- a/profiles/easy
+++ b/profiles/easy
@@ -298,6 +298,11 @@ org.freedesktop.home1.remove-home                               auth_admin_keep
 org.freedesktop.home1.resize-home                               auth_admin_keep
 org.freedesktop.home1.update-home                               auth_admin_keep
 
+# systemd timesync1, hostname1 (bsc#1200098)
+org.freedesktop.timesync1.set-runtime-servers                   auth_admin:auth_admin_keep:auth_admin_keep
+org.freedesktop.hostname1.get-hardware-serial                   auth_admin_keep
+org.freedesktop.hostname1.get-description                       auth_admin_keep
+
 # GNOME control-center (bsc#927508)
 org.gnome.controlcenter.remote-login-helper                     no:no:auth_admin_keep
 # GNOME control-center (bsc#779938)

--- a/profiles/restrictive
+++ b/profiles/restrictive
@@ -299,6 +299,11 @@ org.freedesktop.home1.remove-home                               auth_admin
 org.freedesktop.home1.resize-home                               auth_admin
 org.freedesktop.home1.update-home                               auth_admin
 
+# systemd timesync1, hostname1 (bsc#1200098)
+org.freedesktop.timesync1.set-runtime-servers                   auth_admin:auth_admin:auth_admin
+org.freedesktop.hostname1.get-hardware-serial                   auth_admin_keep
+org.freedesktop.hostname1.get-description                       auth_admin_keep
+
 # GNOME control-center (bsc#927508)
 org.gnome.controlcenter.remote-login-helper                     no:no:auth_admin
 # GNOME control-center (bsc#779938)

--- a/profiles/standard
+++ b/profiles/standard
@@ -291,7 +291,6 @@ org.freedesktop.network1.forcerenew                             auth_admin:auth_
 # incremental addition to handle reboot key events (bsc#1185468)
 org.freedesktop.login1.inhibit-handle-reboot-key                no:yes:yes
 
-
 # systemd homed (boo#1185285)
 org.freedesktop.home1.authenticate-home                         auth_admin_keep
 org.freedesktop.home1.create-home                               auth_admin_keep
@@ -299,6 +298,11 @@ org.freedesktop.home1.passwd-home                               auth_admin_keep
 org.freedesktop.home1.remove-home                               auth_admin_keep
 org.freedesktop.home1.resize-home                               auth_admin_keep
 org.freedesktop.home1.update-home                               auth_admin_keep
+
+# systemd timesync1, hostname1 (bsc#1200098)
+org.freedesktop.timesync1.set-runtime-servers                   auth_admin:auth_admin_keep:auth_admin_keep
+org.freedesktop.hostname1.get-hardware-serial                   auth_admin_keep
+org.freedesktop.hostname1.get-description                       auth_admin_keep
 
 # GNOME control-center (bsc#927508)
 org.gnome.controlcenter.remote-login-helper                     no:no:auth_admin_keep


### PR DESCRIPTION
org.freedesktop.timesync1.set-runtime-servers
org.freedesktop.hostname1.get-hardware-serial
org.freedesktop.hostname1.get-description

https://bugzilla.suse.com/show_bug.cgi?id=1200098