### PR TITLE
iio-sensor-proxy (bsc#1201558): add claim-sensor action

### DIFF
--- a/profiles/easy
+++ b/profiles/easy
@@ -750,3 +750,6 @@ org.usbguard.Policy1.appendRule no:no:auth_admin_keep
 org.usbguard.Policy1.removeRule no:no:auth_admin_keep
 org.usbguard.Devices1.applyDevicePolicy no:no:auth_admin_keep
 org.usbguard1.setParameter no:no:auth_admin_keep
+
+# iio-sensor-proxy sensor access (bsc#1201558)
+net.hadess.SensorProxy.claim-sensor no:no:yes

--- a/profiles/restrictive
+++ b/profiles/restrictive
@@ -751,3 +751,6 @@ org.usbguard.Policy1.appendRule no:no:auth_admin
 org.usbguard.Policy1.removeRule no:no:auth_admin
 org.usbguard.Devices1.applyDevicePolicy no:no:auth_admin
 org.usbguard1.setParameter no:no:auth_admin
+
+# iio-sensor-proxy sensor access (bsc#1201558)
+net.hadess.SensorProxy.claim-sensor no:no:yes

--- a/profiles/standard
+++ b/profiles/standard
@@ -751,3 +751,6 @@ org.usbguard.Policy1.appendRule no:no:auth_admin
 org.usbguard.Policy1.removeRule no:no:auth_admin
 org.usbguard.Devices1.applyDevicePolicy no:no:auth_admin
 org.usbguard1.setParameter no:no:auth_admin
+
+# iio-sensor-proxy sensor access (bsc#1201558)
+net.hadess.SensorProxy.claim-sensor no:no:yes


### PR DESCRIPTION
Hardening the authentication requirements for restrictive probably will
easily raise hell since authentication popups on login, maybe even
multiple ones would be the result. Therefore keep the upstream setting
everywhere.