### PR TITLE
 Fix Settings prompts on desktop

### DIFF
--- a/profiles/easy
+++ b/profiles/easy
@@ -184,8 +184,8 @@ org.kde.kded.smart.smartctl                                     auth_admin:auth_
 org.kde.kinfocenter.dmidecode.systeminformation                 no:yes:yes
 
 # systemd (bsc#641924)
-org.freedesktop.hostname1.set-hostname                          auth_admin_keep:auth_admin_keep:yes
-org.freedesktop.hostname1.set-static-hostname                   auth_admin_keep:auth_admin_keep:yes
+org.freedesktop.hostname1.set-hostname                          auth_admin
+org.freedesktop.hostname1.set-static-hostname                   auth_admin
 org.freedesktop.hostname1.set-machine-info                      auth_admin
 org.freedesktop.systemd1.reply-password                         auth_admin
 org.freedesktop.timedate1.set-time                              auth_admin_keep

--- a/profiles/easy
+++ b/profiles/easy
@@ -184,16 +184,16 @@ org.kde.kded.smart.smartctl                                     auth_admin:auth_
 org.kde.kinfocenter.dmidecode.systeminformation                 no:yes:yes
 
 # systemd (bsc#641924)
-org.freedesktop.hostname1.set-hostname                          auth_admin
-org.freedesktop.hostname1.set-static-hostname                   auth_admin
+org.freedesktop.hostname1.set-hostname                          auth_admin_keep:auth_admin_keep:yes
+org.freedesktop.hostname1.set-static-hostname                   auth_admin_keep:auth_admin_keep:yes
 org.freedesktop.hostname1.set-machine-info                      auth_admin
 org.freedesktop.systemd1.reply-password                         auth_admin
 org.freedesktop.timedate1.set-time                              auth_admin_keep
 org.freedesktop.timedate1.set-timezone                          auth_admin_keep:auth_admin_keep:yes
 org.freedesktop.timedate1.set-ntp                               auth_admin_keep
 org.freedesktop.timedate1.set-local-rtc                         auth_admin_keep
-org.freedesktop.locale1.set-locale                              auth_admin_keep
-org.freedesktop.locale1.set-keyboard                            auth_admin_keep
+org.freedesktop.locale1.set-locale                              auth_admin_keep:auth_admin_keep:yes
+org.freedesktop.locale1.set-keyboard                            auth_admin_keep:auth_admin_keep:yes
 org.freedesktop.login1.attach-device                            auth_admin_keep
 org.freedesktop.login1.flush-devices                            auth_admin_keep
 org.freedesktop.login1.power-off                                auth_admin_keep:auth_admin_keep:yes


### PR DESCRIPTION
Similar to #84, the user is prompted for admin password for simple stuff like changing hostname, setting locale and keyboard layouts

This patch sets the policy to match other distro's setup

Signed-off-by: Luca Di Maio <luca.dimaio1@gmail.com>