### PR TITLE
rename com.deepin.api to org.deepin.dde (bsc#1211376)

### DIFF
--- a/profiles/easy
+++ b/profiles/easy
@@ -731,8 +731,8 @@ dev.jonmagon.kdiskmark.helper.init                              no:no:auth_admin
 com.deepin.pkexec.deepin-system-monitor.kill no:no:auth_admin_keep
 com.deepin.pkexec.deepin-system-monitor.renice no:no:auth_admin_keep
 com.deepin.pkexec.deepin-system-monitor.systemctl no:no:auth_admin_keep
-#  deepin desktop environment helpers (bsc#1070943)
-com.deepin.api.device.unblock-bluetooth-devices no:no:auth_admin_keep
+# deepin desktop environment helpers (bsc#1070943, bsc#1211376)
+org.deepin.dde.device.unblock-bluetooth-devices no:no:auth_admin_keep
 
 # setroubleshoot (boo#1186344)
 org.fedoraproject.setroubleshootfixit.write                     auth_admin

--- a/profiles/restrictive
+++ b/profiles/restrictive
@@ -732,8 +732,8 @@ dev.jonmagon.kdiskmark.helper.init                              no:no:auth_admin
 com.deepin.pkexec.deepin-system-monitor.kill no:no:auth_admin
 com.deepin.pkexec.deepin-system-monitor.renice no:no:auth_admin
 com.deepin.pkexec.deepin-system-monitor.systemctl no:no:auth_admin
-# deepin desktop environment helpers (bsc#1070943)
-com.deepin.api.device.unblock-bluetooth-devices no:no:auth_admin_keep
+# deepin desktop environment helpers (bsc#1070943, bsc#1211376)
+org.deepin.dde.device.unblock-bluetooth-devices no:no:auth_admin_keep
 
 # setroubleshoot (boo#1186344)
 org.fedoraproject.setroubleshootfixit.write                     auth_admin

--- a/profiles/standard
+++ b/profiles/standard
@@ -732,8 +732,8 @@ dev.jonmagon.kdiskmark.helper.init                              no:no:auth_admin
 com.deepin.pkexec.deepin-system-monitor.kill no:no:auth_admin_keep
 com.deepin.pkexec.deepin-system-monitor.renice no:no:auth_admin_keep
 com.deepin.pkexec.deepin-system-monitor.systemctl no:no:auth_admin_keep
-# deepin desktop environment helpers (bsc#1070943)
-com.deepin.api.device.unblock-bluetooth-devices no:no:auth_admin_keep
+# deepin desktop environment helpers (bsc#1070943, bsc#1211376)
+org.deepin.dde.device.unblock-bluetooth-devices no:no:auth_admin_keep
 
 # setroubleshoot (boo#1186344)
 org.fedoraproject.setroubleshootfixit.write                     auth_admin


### PR DESCRIPTION
rpmlint diagnostics for this are found here:

https://build.opensuse.org/public/build/X11:Deepin:Factory/openSUSE_Tumbleweed/x86_64/deepin-api/rpmlint.log

The `manage-locale` action will not be whitelisted, since the functionality is broken on openSUSE.