### PR TITLE
profiles: drop dead mousepad action

### DIFF
--- a/profiles/easy
+++ b/profiles/easy
@@ -688,9 +688,6 @@ net.luckybackup.su                                              auth_admin
 # lightdm-gtk-greeter-settings (bsc#1135695)
 com.ubuntu.pkexec.lightdm-gtk-greeter-settings                  auth_admin:auth_admin:auth_self_keep
 
-# mousepad run as root in X11 (bsc#1143216)
-org.xfce.mousepad                                               no:auth_admin:auth_admin
-
 # calamares run as root in X11 (bsc#1143147)
 com.github.calamares.calamares.pkexec.run                       no:no:auth_admin
 

--- a/profiles/restrictive
+++ b/profiles/restrictive
@@ -689,9 +689,6 @@ net.luckybackup.su                                              auth_admin
 # lightdm-gtk-greeter-settings (bsc#1135695)
 com.ubuntu.pkexec.lightdm-gtk-greeter-settings                  auth_admin
 
-# mousepad run as root in X11 (bsc#1143216)
-org.xfce.mousepad                                               no:no:auth_admin
-
 # calamares run as root in X11 (bsc#1143147)
 com.github.calamares.calamares.pkexec.run                       no:no:auth_admin
 

--- a/profiles/standard
+++ b/profiles/standard
@@ -689,9 +689,6 @@ net.luckybackup.su                                              auth_admin
 # lightdm-gtk-greeter-settings (bsc#1135695)
 com.ubuntu.pkexec.lightdm-gtk-greeter-settings                  auth_admin
 
-# mousepad run as root in X11 (bsc#1143216)
-org.xfce.mousepad                                               no:auth_admin:auth_admin
-
 # calamares run as root in X11 (bsc#1143147)
 com.github.calamares.calamares.pkexec.run                       no:no:auth_admin
 


### PR DESCRIPTION
The Polkit part was dropped from openSUSE:Factory/mousepad via sr#1087353.