### PR TITLE
Whitelist org.freedesktop.systemd1.bypass-dump-ratelimit (bsc#1211978).

### DIFF
--- a/profiles/easy
+++ b/profiles/easy
@@ -306,6 +306,9 @@ org.freedesktop.timesync1.set-runtime-servers                   auth_admin:auth_
 org.freedesktop.hostname1.get-hardware-serial                   auth_admin_keep
 org.freedesktop.hostname1.get-description                       auth_admin_keep
 
+# systemd Dump*() rate-limiting (bsc#1211978)
+org.freedesktop.systemd1.bypass-dump-ratelimit auth_admin:auth_admin:auth_admin_keep
+
 # GNOME control-center (bsc#927508)
 org.gnome.controlcenter.remote-login-helper                     no:no:auth_admin_keep
 # GNOME control-center (bsc#779938)

--- a/profiles/restrictive
+++ b/profiles/restrictive
@@ -307,6 +307,9 @@ org.freedesktop.timesync1.set-runtime-servers                   auth_admin:auth_
 org.freedesktop.hostname1.get-hardware-serial                   auth_admin_keep
 org.freedesktop.hostname1.get-description                       auth_admin_keep
 
+# systemd Dump*() rate-limiting (bsc#1211978)
+org.freedesktop.systemd1.bypass-dump-ratelimit auth_admin:auth_admin:auth_admin_keep
+
 # GNOME control-center (bsc#927508)
 org.gnome.controlcenter.remote-login-helper                     no:no:auth_admin
 # GNOME control-center (bsc#779938)

--- a/profiles/standard
+++ b/profiles/standard
@@ -307,6 +307,9 @@ org.freedesktop.timesync1.set-runtime-servers                   auth_admin:auth_
 org.freedesktop.hostname1.get-hardware-serial                   auth_admin_keep
 org.freedesktop.hostname1.get-description                       auth_admin_keep
 
+# systemd Dump*() rate-limiting (bsc#1211978)
+org.freedesktop.systemd1.bypass-dump-ratelimit auth_admin:auth_admin:auth_admin_keep
+
 # GNOME control-center (bsc#927508)
 org.gnome.controlcenter.remote-login-helper                     no:no:auth_admin_keep
 # GNOME control-center (bsc#779938)


### PR DESCRIPTION
https://bugzilla.suse.com/show_bug.cgi?id=1211978#c4