### PR TITLE
deepin-api: provide backward compatibility whitelisting (bsc#1214101)

### DIFF
--- a/profiles/easy
+++ b/profiles/easy
@@ -732,6 +732,7 @@ com.deepin.pkexec.deepin-system-monitor.kill no:no:auth_admin_keep
 com.deepin.pkexec.deepin-system-monitor.renice no:no:auth_admin_keep
 com.deepin.pkexec.deepin-system-monitor.systemctl no:no:auth_admin_keep
 # deepin desktop environment helpers (bsc#1070943, bsc#1211376)
+com.deepin.api.device.unblock-bluetooth-devices no:no:auth_admin_keep
 org.deepin.dde.device.unblock-bluetooth-devices no:no:auth_admin_keep
 
 # setroubleshoot (boo#1186344)

--- a/profiles/restrictive
+++ b/profiles/restrictive
@@ -733,6 +733,7 @@ com.deepin.pkexec.deepin-system-monitor.kill no:no:auth_admin
 com.deepin.pkexec.deepin-system-monitor.renice no:no:auth_admin
 com.deepin.pkexec.deepin-system-monitor.systemctl no:no:auth_admin
 # deepin desktop environment helpers (bsc#1070943, bsc#1211376)
+com.deepin.api.device.unblock-bluetooth-devices no:no:auth_admin_keep
 org.deepin.dde.device.unblock-bluetooth-devices no:no:auth_admin_keep
 
 # setroubleshoot (boo#1186344)

--- a/profiles/standard
+++ b/profiles/standard
@@ -733,6 +733,7 @@ com.deepin.pkexec.deepin-system-monitor.kill no:no:auth_admin_keep
 com.deepin.pkexec.deepin-system-monitor.renice no:no:auth_admin_keep
 com.deepin.pkexec.deepin-system-monitor.systemctl no:no:auth_admin_keep
 # deepin desktop environment helpers (bsc#1070943, bsc#1211376)
+com.deepin.api.device.unblock-bluetooth-devices no:no:auth_admin_keep
 org.deepin.dde.device.unblock-bluetooth-devices no:no:auth_admin_keep
 
 # setroubleshoot (boo#1186344)


### PR DESCRIPTION
Our deepin maintainer has difficulties bringing the new version into Factory, thus we need both names for the moment.