### PR TITLE
profiles: remove no longer used device-rebind action

### DIFF
--- a/profiles/easy
+++ b/profiles/easy
@@ -61,7 +61,6 @@ org.freedesktop.packagekit.system-sources-configure             auth_admin_keep
 org.freedesktop.packagekit.system-sources-refresh               no:no:yes
 org.freedesktop.packagekit.system-network-proxy-configure       auth_admin_keep
 org.freedesktop.packagekit.cancel-foreign                       auth_admin:auth_admin:auth_admin_keep
-org.freedesktop.packagekit.device-rebind                        auth_admin_keep
 org.freedesktop.packagekit.upgrade-system                       auth_admin
 org.freedesktop.packagekit.repair-system                        auth_admin
 # PackageKit / systemd offline updates (bsc#798885)

--- a/profiles/restrictive
+++ b/profiles/restrictive
@@ -62,7 +62,6 @@ org.freedesktop.packagekit.system-sources-configure             auth_admin_keep
 org.freedesktop.packagekit.system-sources-refresh               no:no:yes
 org.freedesktop.packagekit.system-network-proxy-configure       auth_admin_keep
 org.freedesktop.packagekit.cancel-foreign                       auth_admin:auth_admin:auth_admin_keep
-org.freedesktop.packagekit.device-rebind                        auth_admin_keep
 org.freedesktop.packagekit.upgrade-system                       auth_admin
 org.freedesktop.packagekit.repair-system                        auth_admin
 # PackageKit / systemd offline updates (bsc#798885)

--- a/profiles/standard
+++ b/profiles/standard
@@ -62,7 +62,6 @@ org.freedesktop.packagekit.system-sources-configure             auth_admin_keep
 org.freedesktop.packagekit.system-sources-refresh               no:no:yes
 org.freedesktop.packagekit.system-network-proxy-configure       auth_admin_keep
 org.freedesktop.packagekit.cancel-foreign                       auth_admin:auth_admin:auth_admin_keep
-org.freedesktop.packagekit.device-rebind                        auth_admin_keep
 org.freedesktop.packagekit.upgrade-system                       auth_admin
 org.freedesktop.packagekit.repair-system                        auth_admin
 # PackageKit / systemd offline updates (bsc#798885)


### PR DESCRIPTION
This has been removed upstream in commit db1a9c4af:

    https://github.com/PackageKit/PackageKit/commit/db1a9c4af758fbe62d297f5516a46085cbd84f54)
    https://github.com/PackageKit/PackageKit/issues/567

The Factory package no longer contains this.