### PR TITLE
profiles: power-profiles-daemon (bsc#1219957)

### DIFF
--- a/profiles/easy
+++ b/profiles/easy
@@ -752,9 +752,9 @@ org.fedoraproject.setroubleshootfixit.write                     auth_admin
 #  zypp-gui repository manager (bsc#1188364)
 zypp.gui.pkexec.run auth_admin:auth_admin:auth_admin_keep
 
-# a daemon that deals with system power settings (bsc#1189900)
-net.hadess.PowerProfiles.switch-profile auth_admin:yes:yes
-net.hadess.PowerProfiles.hold-profile auth_admin:yes:yes
+# a daemon that deals with system power settings (bsc#1189900, bsc#1219957)
+org.freedesktop.UPower.PowerProfiles.switch-profile auth_admin:yes:yes
+org.freedesktop.UPower.PowerProfiles.hold-profile auth_admin:yes:yes
 
 # kcron dbus helper (bsc#1193945)
 local.kcron.crontab.save no:no:auth_admin_keep

--- a/profiles/restrictive
+++ b/profiles/restrictive
@@ -753,9 +753,9 @@ org.fedoraproject.setroubleshootfixit.write                     auth_admin
 #  zypp-gui repository manager (bsc#1188364)
 zypp.gui.pkexec.run no:no:auth_admin_keep
 
-# a daemon that deals with system power settings (bsc#1189900)
-net.hadess.PowerProfiles.switch-profile no:no:yes
-net.hadess.PowerProfiles.hold-profile no:no:yes
+# a daemon that deals with system power settings (bsc#1189900, bsc#1219957)
+org.freedesktop.UPower.PowerProfiles.switch-profile no:no:yes
+org.freedesktop.UPower.PowerProfiles.hold-profile no:no:yes
 
 # kcron dbus helper (bsc#1193945)
 local.kcron.crontab.save no:no:auth_admin

--- a/profiles/standard
+++ b/profiles/standard
@@ -753,9 +753,9 @@ org.fedoraproject.setroubleshootfixit.write                     auth_admin
 #  zypp-gui repository manager (bsc#1188364)
 zypp.gui.pkexec.run auth_admin:auth_admin:auth_admin_keep
 
-# a daemon that deals with system power settings (bsc#1189900)
-net.hadess.PowerProfiles.switch-profile no:no:yes
-net.hadess.PowerProfiles.hold-profile no:no:yes
+# a daemon that deals with system power settings (bsc#1189900, bsc#1219957)
+org.freedesktop.UPower.PowerProfiles.switch-profile no:no:yes
+org.freedesktop.UPower.PowerProfiles.hold-profile no:no:yes
 
 # kcron dbus helper (bsc#1193945)
 local.kcron.crontab.save no:no:auth_admin_keep


### PR DESCRIPTION
The service was renamed from `net.hadess.PowerProfiles`, however the old service is being kept to ensure backwards compatibility, for a while.
https://bugzilla.suse.com/show_bug.cgi?id=1219956
https://bugzilla.suse.com/show_bug.cgi?id=1219957