### PR TITLE
whitelist gnome-control-center remote-session-helper (bsc#1220862)

### DIFF
--- a/profiles/easy
+++ b/profiles/easy
@@ -320,6 +320,8 @@ org.gnome.controlcenter.remote-login-helper                     no:no:auth_admin
 # GNOME control-center (bsc#779938)
 org.gnome.controlcenter.user-accounts.administration            auth_admin:auth_admin:auth_admin_keep
 org.gnome.controlcenter.datetime.configure                      auth_admin:auth_admin:auth_admin_keep
+# gnome-control-center enable remote login on systemd level (bsc#1220862)
+org.gnome.controlcenter.remote-session-helper                   no:no:auth_admin_keep
 
 # budgie-control-center (bsc#1195023)
 org.buddiesofbudgie.controlcenter.datetime.configure		no:no:auth_admin_keep

--- a/profiles/restrictive
+++ b/profiles/restrictive
@@ -321,6 +321,8 @@ org.gnome.controlcenter.remote-login-helper                     no:no:auth_admin
 # GNOME control-center (bsc#779938)
 org.gnome.controlcenter.user-accounts.administration            no:no:auth_admin_keep
 org.gnome.controlcenter.datetime.configure                      no:no:auth_admin_keep
+# gnome-control-center enable remote login on systemd level (bsc#1220862)
+org.gnome.controlcenter.remote-session-helper                   no:no:auth_admin_keep
 
 # budgie-control-center (bsc#1195023)
 org.buddiesofbudgie.controlcenter.datetime.configure		no:no:auth_admin_keep

--- a/profiles/standard
+++ b/profiles/standard
@@ -321,6 +321,8 @@ org.gnome.controlcenter.remote-login-helper                     no:no:auth_admin
 # GNOME control-center (bsc#779938)
 org.gnome.controlcenter.user-accounts.administration            no:no:auth_admin_keep
 org.gnome.controlcenter.datetime.configure                      no:no:auth_admin_keep
+# gnome-control-center enable remote login on systemd level (bsc#1220862)
+org.gnome.controlcenter.remote-session-helper                   no:no:auth_admin_keep
 
 # budgie-control-center (bsc#1195023)
 org.buddiesofbudgie.controlcenter.datetime.configure		no:no:auth_admin_keep


### PR DESCRIPTION
Making the requirement more restrictive (i.e. setting it to `auth_admin_keep`) likely will break the imply logic that this action has. Thus stick with the keep value in all profiles.