### PR TITLE
profiles: remove pseudo auth action kcmkwallet5 (bsc#1217190)

### DIFF
--- a/profiles/easy
+++ b/profiles/easy
@@ -182,8 +182,6 @@ org.kde.kcontrol.kcmsddm.uninstalltheme                         no:no:auth_admin
 # sddm kcm incremental addition (bsc#1145182)
 org.kde.kcontrol.kcmsddm.reset                                  no:no:auth_admin_keep
 org.kde.kcontrol.kcmsddm.sync                                   no:no:auth_admin_keep
-# kwallet5 (bsc#849739, bsc#1033296)
-org.kde.kcontrol.kcmkwallet5.save                               no:no:yes
 # KDE smartctl helper (bsc#1176742)
 org.kde.kded.smart.smartctl                                     auth_admin:auth_admin:yes
 # kinfocenter5 (bsc#1199735)

--- a/profiles/restrictive
+++ b/profiles/restrictive
@@ -183,8 +183,6 @@ org.kde.kcontrol.kcmsddm.uninstalltheme                         no:no:auth_admin
 # sddm kcm incremental addition (bsc#1145182)
 org.kde.kcontrol.kcmsddm.reset                                  no:no:auth_admin
 org.kde.kcontrol.kcmsddm.sync                                   no:no:auth_admin
-# kwallet5 (bsc#849739, bsc#1033296)
-org.kde.kcontrol.kcmkwallet5.save                               no:no:auth_admin_keep
 # KDE smartctl helper (bsc#1176742)
 org.kde.kded.smart.smartctl                                     no:no:auth_admin
 # kinfocenter5 (bsc#1199735)

--- a/profiles/standard
+++ b/profiles/standard
@@ -183,8 +183,6 @@ org.kde.kcontrol.kcmsddm.uninstalltheme                         no:no:auth_admin
 # sddm kcm incremental addition (bsc#1145182)
 org.kde.kcontrol.kcmsddm.reset                                  no:no:auth_admin_keep
 org.kde.kcontrol.kcmsddm.sync                                   no:no:auth_admin_keep
-# kwallet5 (bsc#849739, bsc#1033296)
-org.kde.kcontrol.kcmkwallet5.save                               no:no:yes
 # KDE smartctl helper (bsc#1176742)
 org.kde.kded.smart.smartctl                                     no:auth_admin:yes
 # kinfocenter5 (bsc#1199735)


### PR DESCRIPTION
During the kwalletmanager audit for KDE6 we found out that this action effectively does nothing and is only for pseudo authentication. It's no longer packaged (removed via a SUSE specific patch). Drop the whitelisting.