### PR TITLE
profiles: whitelist systemd v257 actions (bsc#1233295)

### DIFF
--- a/profiles/easy
+++ b/profiles/easy
@@ -252,6 +252,8 @@ org.freedesktop.login1.lock-sessions                            auth_admin_keep
 org.freedesktop.login1.set-reboot-to-firmware-setup             auth_admin_keep
 org.freedesktop.login1.set-wall-message                         auth_admin_keep
 org.freedesktop.machine1.host-login                             auth_admin:auth_admin:yes
+# v257 addition (bsc#1233295)
+org.freedesktop.machine1.create-machine                         auth_admin:auth_admin:auth_admin_keep
 # systemd follow-up for resolve actions (bsc#1096907)
 org.freedesktop.resolve1.register-service                       auth_admin
 org.freedesktop.resolve1.unregister-service                     auth_admin
@@ -265,6 +267,12 @@ org.freedesktop.resolve1.set-llmnr                              auth_admin:auth_
 org.freedesktop.resolve1.set-default-route                      auth_admin:auth_admin:auth_admin_keep
 org.freedesktop.resolve1.set-domains                            auth_admin:auth_admin:auth_admin_keep
 org.freedesktop.resolve1.set-dns-servers                        auth_admin:auth_admin:auth_admin_keep
+# v257 addition (bsc#1233295)
+org.freedesktop.resolve1.subscribe-query-results                auth_admin:auth_admin:auth_admin_keep
+org.freedesktop.resolve1.dump-cache                             auth_admin:auth_admin:auth_admin_keep
+org.freedesktop.resolve1.dump-server-state                      auth_admin:auth_admin:auth_admin_keep
+org.freedesktop.resolve1.dump-statistics                        auth_admin:auth_admin:auth_admin_keep
+org.freedesktop.resolve1.reset-statistics                       auth_admin:auth_admin:auth_admin_keep
 # systemd get-product-uuid incremental addition (bsc#1127847)
 org.freedesktop.hostname1.get-product-uuid                      auth_admin
 # systemd org.freedesktop.login1.* services (bsc#1133843)
@@ -313,6 +321,8 @@ org.freedesktop.home1.passwd-home                               auth_admin_keep
 org.freedesktop.home1.remove-home                               auth_admin_keep
 org.freedesktop.home1.resize-home                               auth_admin_keep
 org.freedesktop.home1.update-home                               auth_admin_keep
+# v257 addition (bsc#1233295)
+org.freedesktop.home1.update-home-by-owner                      auth_admin_keep:auth_admin_keep:yes
 
 # systemd timesync1, hostname1 (bsc#1200098)
 org.freedesktop.timesync1.set-runtime-servers                   auth_admin:auth_admin_keep:auth_admin_keep

--- a/profiles/restrictive
+++ b/profiles/restrictive
@@ -253,6 +253,8 @@ org.freedesktop.login1.lock-sessions                            auth_admin_keep
 org.freedesktop.login1.set-reboot-to-firmware-setup             auth_admin_keep
 org.freedesktop.login1.set-wall-message                         auth_admin_keep
 org.freedesktop.machine1.host-login                             auth_admin:auth_admin:yes
+# v257 addition (bsc#1233295)
+org.freedesktop.machine1.create-machine                         auth_admin:auth_admin:auth_admin
 # systemd follow-up for resolve actions (bsc#1096907)
 org.freedesktop.resolve1.register-service                       auth_admin
 org.freedesktop.resolve1.unregister-service                     auth_admin
@@ -266,6 +268,12 @@ org.freedesktop.resolve1.set-llmnr                              auth_admin
 org.freedesktop.resolve1.set-default-route                      auth_admin
 org.freedesktop.resolve1.set-domains                            auth_admin
 org.freedesktop.resolve1.set-dns-servers                        auth_admin
+# v257 addition (bsc#1233295)
+org.freedesktop.resolve1.subscribe-query-results                auth_admin:auth_admin:auth_admin_keep
+org.freedesktop.resolve1.dump-cache                             auth_admin:auth_admin:auth_admin_keep
+org.freedesktop.resolve1.dump-server-state                      auth_admin:auth_admin:auth_admin_keep
+org.freedesktop.resolve1.dump-statistics                        auth_admin:auth_admin:auth_admin_keep
+org.freedesktop.resolve1.reset-statistics                       auth_admin:auth_admin:auth_admin_keep
 # systemd get-product-uuid incremental addition (bsc#1127847)
 org.freedesktop.hostname1.get-product-uuid                      auth_admin
 # systemd org.freedesktop.login1.* services (bsc#1133843)
@@ -314,6 +322,8 @@ org.freedesktop.home1.passwd-home                               auth_admin
 org.freedesktop.home1.remove-home                               auth_admin
 org.freedesktop.home1.resize-home                               auth_admin
 org.freedesktop.home1.update-home                               auth_admin
+# v257 addition (bsc#1233295)
+org.freedesktop.home1.update-home-by-owner                      auth_admin_keep:auth_admin_keep:yes
 
 # systemd timesync1, hostname1 (bsc#1200098)
 org.freedesktop.timesync1.set-runtime-servers                   auth_admin:auth_admin:auth_admin

--- a/profiles/standard
+++ b/profiles/standard
@@ -253,6 +253,8 @@ org.freedesktop.login1.lock-sessions                            auth_admin_keep
 org.freedesktop.login1.set-reboot-to-firmware-setup             auth_admin_keep
 org.freedesktop.login1.set-wall-message                         auth_admin_keep
 org.freedesktop.machine1.host-login                             auth_admin:auth_admin:yes
+# v257 addition (bsc#1233295)
+org.freedesktop.machine1.create-machine                         auth_admin:auth_admin:auth_admin_keep
 # systemd follow-up for resolve actions (bsc#1096907)
 org.freedesktop.resolve1.register-service                       auth_admin
 org.freedesktop.resolve1.unregister-service                     auth_admin
@@ -266,6 +268,12 @@ org.freedesktop.resolve1.set-llmnr                              auth_admin:auth_
 org.freedesktop.resolve1.set-default-route                      auth_admin:auth_admin:auth_admin_keep
 org.freedesktop.resolve1.set-domains                            auth_admin:auth_admin:auth_admin_keep
 org.freedesktop.resolve1.set-dns-servers                        auth_admin:auth_admin:auth_admin_keep
+# v257 addition (bsc#1233295)
+org.freedesktop.resolve1.subscribe-query-results                auth_admin:auth_admin:auth_admin_keep
+org.freedesktop.resolve1.dump-cache                             auth_admin:auth_admin:auth_admin_keep
+org.freedesktop.resolve1.dump-server-state                      auth_admin:auth_admin:auth_admin_keep
+org.freedesktop.resolve1.dump-statistics                        auth_admin:auth_admin:auth_admin_keep
+org.freedesktop.resolve1.reset-statistics                       auth_admin:auth_admin:auth_admin_keep
 # systemd get-product-uuid incremental addition (bsc#1127847)
 org.freedesktop.hostname1.get-product-uuid                      auth_admin
 # systemd org.freedesktop.login1.* services (bsc#1133843)
@@ -314,6 +322,8 @@ org.freedesktop.home1.passwd-home                               auth_admin_keep
 org.freedesktop.home1.remove-home                               auth_admin_keep
 org.freedesktop.home1.resize-home                               auth_admin_keep
 org.freedesktop.home1.update-home                               auth_admin_keep
+# v257 addition (bsc#1233295)
+org.freedesktop.home1.update-home-by-owner                      auth_admin_keep:auth_admin_keep:yes
 
 # systemd timesync1, hostname1 (bsc#1200098)
 org.freedesktop.timesync1.set-runtime-servers                   auth_admin:auth_admin_keep:auth_admin_keep


### PR DESCRIPTION
For create-machine in the restrictive profile I've tightened the setting to `auth_admin` also for local users. This is a rather powerful action and one that shouldn't be needed a lot, so not keeping authentication seems acceptable here.