### PR TITLE
man page polkit-default-privs(5): fix path for local override (bsc#12…

### DIFF
--- a/man/polkit-default-privs.5
+++ b/man/polkit-default-privs.5
@@ -2,12 +2,12 @@
 .\"     Title: polkit-default-privs
 .\"    Author: [see the "AUTHORS" section]
 .\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
-.\"      Date: 07/20/2021
+.\"      Date: 01/31/2025
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "POLKIT\-DEFAULT\-PRI" "5" "07/20/2021" "\ \&" "\ \&"
+.TH "POLKIT\-DEFAULT\-PRI" "5" "01/31/2025" "\ \&" "\ \&"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -96,7 +96,7 @@ This line configures the org\&.spice\-space\&.lowlevelusbaccess polkit action to
 This line configures the net\&.connman\&.modify polkit action to require admin authentication for all three user context types: remote users, inactive users and active users\&.
 .SH "FILES"
 .sp
-/usr/etc/polkit\-default\-privs/local\&.template is a template for /etc/polkit\-default\-privs\&.local
+/usr/etc/polkit\-default\-privs/local\&.template is a template for /etc/polkit\-default\-privs/local
 .sp
 /usr/etc/polkit\-default\-privs/profiles/restrictive
 .sp

--- a/man/polkit-default-privs.adoc
+++ b/man/polkit-default-privs.adoc
@@ -78,7 +78,7 @@ and active users.
 FILES
 -----
 
-`/usr/etc/polkit-default-privs/local.template` is a template for  `/etc/polkit-default-privs.local`
+`/usr/etc/polkit-default-privs/local.template` is a template for  `/etc/polkit-default-privs/local`
 
 `/usr/etc/polkit-default-privs/profiles/restrictive`
 


### PR DESCRIPTION
…36538)

this have been moved into /etc/polkit-default-privs/local.