### PR TITLE
backport of tuned actions SLE-15-SP7 (bsc#1236016)

### DIFF
--- a/profiles/polkit-default-privs.easy
+++ b/profiles/polkit-default-privs.easy
@@ -958,8 +958,14 @@ com.redhat.tuned.instance_get_devices           yes:yes:yes
 # additional instance create/destroy and PPD methods (bsc#1232412)
 com.redhat.tuned.instance_create                auth_admin:auth_admin:auth_admin_keep
 com.redhat.tuned.instance_destroy               auth_admin:auth_admin:auth_admin_keep
-net.hadess.PowerProfiles.HoldProfile            no:no:yes
-net.hadess.PowerProfiles.ReleaseProfile         no:no:yes
+# tuned-ppd (bsc#1236029)
+# renamed some actions & compatibility with UPower interface
+net.hadess.PowerProfiles.hold-profile           no:no:yes
+net.hadess.PowerProfiles.release-profile        no:no:yes
+net.hadess.PowerProfiles.switch-profile         no:no:yes
+# this action is currently only found in tuned-ppd.
+# once upower-daemon implements it, this should be moved into the UPower section
+org.freedesktop.UPower.PowerProfiles.release-profile no:no:yes
 
 # backintime (bsc#1007723)
 net.launchpad.backintime.UdevRuleSave		auth_admin:auth_admin:auth_admin

--- a/profiles/polkit-default-privs.easy
+++ b/profiles/polkit-default-privs.easy
@@ -948,6 +948,8 @@ com.redhat.tuned.log_capture_start		auth_admin:auth_admin:yes
 com.redhat.tuned.get_all_plugins                yes:yes:yes
 com.redhat.tuned.get_plugin_documentation       yes:yes:yes
 com.redhat.tuned.get_plugin_hints               yes:yes:yes
+# incremental addition (bsc#1185418)
+com.redhat.tuned.post_loaded_profile            yes:yes:yes
 
 # backintime (bsc#1007723)
 net.launchpad.backintime.UdevRuleSave		auth_admin:auth_admin:auth_admin

--- a/profiles/polkit-default-privs.easy
+++ b/profiles/polkit-default-privs.easy
@@ -950,6 +950,8 @@ com.redhat.tuned.get_plugin_documentation       yes:yes:yes
 com.redhat.tuned.get_plugin_hints               yes:yes:yes
 # incremental addition (bsc#1185418)
 com.redhat.tuned.post_loaded_profile            yes:yes:yes
+# addition of acquire_devices method (bsc#1208727)
+com.redhat.tuned.instance_acquire_devices       auth_admin:auth_admin:yes
 
 # backintime (bsc#1007723)
 net.launchpad.backintime.UdevRuleSave		auth_admin:auth_admin:auth_admin

--- a/profiles/polkit-default-privs.easy
+++ b/profiles/polkit-default-privs.easy
@@ -925,15 +925,15 @@ org.blueman.rfkill.setstate			auth_admin:auth_admin_keep:yes
 
 # tuned (bsc#1007279)
 com.redhat.tuned.active_profile			yes
-com.redhat.tuned.disable			auth_admin:auth_admin:yes
+com.redhat.tuned.disable			auth_admin:auth_admin:auth_admin_keep
 com.redhat.tuned.is_running			yes
 com.redhat.tuned.profile_info 			yes
 com.redhat.tuned.profiles			yes
 com.redhat.tuned.profiles2 			yes
 com.redhat.tuned.recommend_profile 		yes
-com.redhat.tuned.reload				auth_admin:auth_admin:yes
-com.redhat.tuned.start				auth_admin:auth_admin:yes
-com.redhat.tuned.stop				auth_admin:auth_admin:yes
+com.redhat.tuned.reload				auth_admin:auth_admin:auth_admin_keep
+com.redhat.tuned.start				auth_admin:auth_admin:auth_admin_keep
+com.redhat.tuned.stop				auth_admin:auth_admin:auth_admin_keep
 com.redhat.tuned.switch_profile			auth_admin:auth_admin:yes
 # tuned (bsc#1048961)
 com.redhat.tuned.verify_profile			yes:yes:yes
@@ -951,7 +951,7 @@ com.redhat.tuned.get_plugin_hints               yes:yes:yes
 # incremental addition (bsc#1185418)
 com.redhat.tuned.post_loaded_profile            yes:yes:yes
 # addition of acquire_devices method (bsc#1208727)
-com.redhat.tuned.instance_acquire_devices       auth_admin:auth_admin:yes
+com.redhat.tuned.instance_acquire_devices       auth_admin:auth_admin:auth_admin_keep
 # additional getter methods (bsc#1220081)
 com.redhat.tuned.get_instances                  yes:yes:yes
 com.redhat.tuned.instance_get_devices           yes:yes:yes

--- a/profiles/polkit-default-privs.easy
+++ b/profiles/polkit-default-privs.easy
@@ -924,7 +924,6 @@ org.blueman.pppd.pppconnect			auth_admin:auth_admin_keep:yes
 org.blueman.rfkill.setstate			auth_admin:auth_admin_keep:yes
 
 # tuned (bsc#1007279)
-com.redhat.tuned.gui.run			auth_admin
 com.redhat.tuned.active_profile			yes
 com.redhat.tuned.disable			auth_admin:auth_admin:yes
 com.redhat.tuned.is_running			yes

--- a/profiles/polkit-default-privs.easy
+++ b/profiles/polkit-default-privs.easy
@@ -955,6 +955,11 @@ com.redhat.tuned.instance_acquire_devices       auth_admin:auth_admin:yes
 # additional getter methods (bsc#1220081)
 com.redhat.tuned.get_instances                  yes:yes:yes
 com.redhat.tuned.instance_get_devices           yes:yes:yes
+# additional instance create/destroy and PPD methods (bsc#1232412)
+com.redhat.tuned.instance_create                auth_admin:auth_admin:auth_admin_keep
+com.redhat.tuned.instance_destroy               auth_admin:auth_admin:auth_admin_keep
+net.hadess.PowerProfiles.HoldProfile            no:no:yes
+net.hadess.PowerProfiles.ReleaseProfile         no:no:yes
 
 # backintime (bsc#1007723)
 net.launchpad.backintime.UdevRuleSave		auth_admin:auth_admin:auth_admin

--- a/profiles/polkit-default-privs.easy
+++ b/profiles/polkit-default-privs.easy
@@ -952,6 +952,9 @@ com.redhat.tuned.get_plugin_hints               yes:yes:yes
 com.redhat.tuned.post_loaded_profile            yes:yes:yes
 # addition of acquire_devices method (bsc#1208727)
 com.redhat.tuned.instance_acquire_devices       auth_admin:auth_admin:yes
+# additional getter methods (bsc#1220081)
+com.redhat.tuned.get_instances                  yes:yes:yes
+com.redhat.tuned.instance_get_devices           yes:yes:yes
 
 # backintime (bsc#1007723)
 net.launchpad.backintime.UdevRuleSave		auth_admin:auth_admin:auth_admin

--- a/profiles/polkit-default-privs.restrictive
+++ b/profiles/polkit-default-privs.restrictive
@@ -894,6 +894,9 @@ com.redhat.tuned.get_plugin_hints               auth_admin:auth_admin:yes
 com.redhat.tuned.post_loaded_profile            yes:yes:yes
 # addition of acquire_devices method (bsc#1208727)
 com.redhat.tuned.instance_acquire_devices       auth_admin:auth_admin:yes
+# additional getter methods (bsc#1220081)
+com.redhat.tuned.get_instances                  auth_admin:auth_admin:yes
+com.redhat.tuned.instance_get_devices           auth_admin:auth_admin:yes
 
 # backintime (bsc#1007723)
 net.launchpad.backintime.UdevRuleSave		auth_admin:auth_admin:auth_admin

--- a/profiles/polkit-default-privs.restrictive
+++ b/profiles/polkit-default-privs.restrictive
@@ -892,6 +892,8 @@ com.redhat.tuned.get_plugin_documentation       auth_admin:auth_admin:yes
 com.redhat.tuned.get_plugin_hints               auth_admin:auth_admin:yes
 # incremental addition (bsc#1185418)
 com.redhat.tuned.post_loaded_profile            yes:yes:yes
+# addition of acquire_devices method (bsc#1208727)
+com.redhat.tuned.instance_acquire_devices       auth_admin:auth_admin:yes
 
 # backintime (bsc#1007723)
 net.launchpad.backintime.UdevRuleSave		auth_admin:auth_admin:auth_admin

--- a/profiles/polkit-default-privs.restrictive
+++ b/profiles/polkit-default-privs.restrictive
@@ -866,7 +866,6 @@ org.blueman.pppd.pppconnect			auth_admin:auth_admin_keep:auth_admin_keep
 org.blueman.rfkill.setstate			auth_admin:auth_admin_keep:auth_admin_keep
 
 # tuned (bsc#1007279)
-com.redhat.tuned.gui.run			auth_admin
 com.redhat.tuned.active_profile			yes
 com.redhat.tuned.disable			auth_admin:auth_admin:auth_admin
 com.redhat.tuned.is_running			yes

--- a/profiles/polkit-default-privs.restrictive
+++ b/profiles/polkit-default-privs.restrictive
@@ -900,8 +900,14 @@ com.redhat.tuned.instance_get_devices           auth_admin:auth_admin:yes
 # additional instance create/destroy and PPD methods (bsc#1232412)
 com.redhat.tuned.instance_create                auth_admin:auth_admin:auth_admin
 com.redhat.tuned.instance_destroy               auth_admin:auth_admin:auth_admin
-net.hadess.PowerProfiles.HoldProfile            no:no:yes
-net.hadess.PowerProfiles.ReleaseProfile         no:no:yes
+# tuned-ppd (bsc#1236029)
+# renamed some actions & compatibility with UPower interface
+net.hadess.PowerProfiles.hold-profile           no:no:yes
+net.hadess.PowerProfiles.release-profile        no:no:yes
+net.hadess.PowerProfiles.switch-profile         no:no:yes
+# this action is currently only found in tuned-ppd.
+# once upower-daemon implements it, this should be moved into the UPower section
+org.freedesktop.UPower.PowerProfiles.release-profile no:no:yes
 
 # backintime (bsc#1007723)
 net.launchpad.backintime.UdevRuleSave		auth_admin:auth_admin:auth_admin

--- a/profiles/polkit-default-privs.restrictive
+++ b/profiles/polkit-default-privs.restrictive
@@ -890,6 +890,8 @@ com.redhat.tuned.log_capture_start		auth_admin:auth_admin:yes
 com.redhat.tuned.get_all_plugins                auth_admin:auth_admin:yes
 com.redhat.tuned.get_plugin_documentation       auth_admin:auth_admin:yes
 com.redhat.tuned.get_plugin_hints               auth_admin:auth_admin:yes
+# incremental addition (bsc#1185418)
+com.redhat.tuned.post_loaded_profile            yes:yes:yes
 
 # backintime (bsc#1007723)
 net.launchpad.backintime.UdevRuleSave		auth_admin:auth_admin:auth_admin

--- a/profiles/polkit-default-privs.restrictive
+++ b/profiles/polkit-default-privs.restrictive
@@ -897,6 +897,11 @@ com.redhat.tuned.instance_acquire_devices       auth_admin:auth_admin:yes
 # additional getter methods (bsc#1220081)
 com.redhat.tuned.get_instances                  auth_admin:auth_admin:yes
 com.redhat.tuned.instance_get_devices           auth_admin:auth_admin:yes
+# additional instance create/destroy and PPD methods (bsc#1232412)
+com.redhat.tuned.instance_create                auth_admin:auth_admin:auth_admin
+com.redhat.tuned.instance_destroy               auth_admin:auth_admin:auth_admin
+net.hadess.PowerProfiles.HoldProfile            no:no:yes
+net.hadess.PowerProfiles.ReleaseProfile         no:no:yes
 
 # backintime (bsc#1007723)
 net.launchpad.backintime.UdevRuleSave		auth_admin:auth_admin:auth_admin

--- a/profiles/polkit-default-privs.restrictive
+++ b/profiles/polkit-default-privs.restrictive
@@ -873,7 +873,7 @@ com.redhat.tuned.profile_info 			yes
 com.redhat.tuned.profiles			yes
 com.redhat.tuned.profiles2 			yes
 com.redhat.tuned.recommend_profile 		yes
-com.redhat.tuned.reload				auth_admin:auth_admin:yes
+com.redhat.tuned.reload				auth_admin:auth_admin:auth_admin
 com.redhat.tuned.start				auth_admin:auth_admin:auth_admin
 com.redhat.tuned.stop				auth_admin:auth_admin:auth_admin
 com.redhat.tuned.switch_profile			auth_admin:auth_admin:yes
@@ -893,7 +893,7 @@ com.redhat.tuned.get_plugin_hints               auth_admin:auth_admin:yes
 # incremental addition (bsc#1185418)
 com.redhat.tuned.post_loaded_profile            yes:yes:yes
 # addition of acquire_devices method (bsc#1208727)
-com.redhat.tuned.instance_acquire_devices       auth_admin:auth_admin:yes
+com.redhat.tuned.instance_acquire_devices       auth_admin:auth_admin:auth_admin
 # additional getter methods (bsc#1220081)
 com.redhat.tuned.get_instances                  auth_admin:auth_admin:yes
 com.redhat.tuned.instance_get_devices           auth_admin:auth_admin:yes

--- a/profiles/polkit-default-privs.standard
+++ b/profiles/polkit-default-privs.standard
@@ -954,6 +954,9 @@ com.redhat.tuned.get_plugin_hints               auth_admin:auth_self:yes
 com.redhat.tuned.post_loaded_profile            yes:yes:yes
 # addition of acquire_devices method (bsc#1208727)
 com.redhat.tuned.instance_acquire_devices       auth_admin:auth_admin:yes
+# additional getter methods (bsc#1220081)
+com.redhat.tuned.get_instances                  yes:yes:yes
+com.redhat.tuned.instance_get_devices           yes:yes:yes
 
 # backintime (bsc#1007723)
 net.launchpad.backintime.UdevRuleSave		auth_admin:auth_admin:auth_admin

--- a/profiles/polkit-default-privs.standard
+++ b/profiles/polkit-default-privs.standard
@@ -952,6 +952,8 @@ com.redhat.tuned.get_plugin_documentation       auth_admin:auth_self:yes
 com.redhat.tuned.get_plugin_hints               auth_admin:auth_self:yes
 # incremental addition (bsc#1185418)
 com.redhat.tuned.post_loaded_profile            yes:yes:yes
+# addition of acquire_devices method (bsc#1208727)
+com.redhat.tuned.instance_acquire_devices       auth_admin:auth_admin:yes
 
 # backintime (bsc#1007723)
 net.launchpad.backintime.UdevRuleSave		auth_admin:auth_admin:auth_admin

--- a/profiles/polkit-default-privs.standard
+++ b/profiles/polkit-default-privs.standard
@@ -950,6 +950,8 @@ com.redhat.tuned.log_capture_start		auth_admin:auth_admin:yes
 com.redhat.tuned.get_all_plugins                auth_admin:auth_self:yes
 com.redhat.tuned.get_plugin_documentation       auth_admin:auth_self:yes
 com.redhat.tuned.get_plugin_hints               auth_admin:auth_self:yes
+# incremental addition (bsc#1185418)
+com.redhat.tuned.post_loaded_profile            yes:yes:yes
 
 # backintime (bsc#1007723)
 net.launchpad.backintime.UdevRuleSave		auth_admin:auth_admin:auth_admin

--- a/profiles/polkit-default-privs.standard
+++ b/profiles/polkit-default-privs.standard
@@ -960,8 +960,14 @@ com.redhat.tuned.instance_get_devices           yes:yes:yes
 # additional instance create/destroy and PPD methods (bsc#1232412)
 com.redhat.tuned.instance_create                auth_admin:auth_admin:auth_admin
 com.redhat.tuned.instance_destroy               auth_admin:auth_admin:auth_admin
-net.hadess.PowerProfiles.HoldProfile            no:no:yes
-net.hadess.PowerProfiles.ReleaseProfile         no:no:yes
+# tuned-ppd (bsc#1236029)
+# renamed some actions & compatibility with UPower interface
+net.hadess.PowerProfiles.hold-profile           no:no:yes
+net.hadess.PowerProfiles.release-profile        no:no:yes
+net.hadess.PowerProfiles.switch-profile         no:no:yes
+# this action is currently only found in tuned-ppd.
+# once upower-daemon implements it, this should be moved into the UPower section
+org.freedesktop.UPower.PowerProfiles.release-profile no:no:yes
 
 # backintime (bsc#1007723)
 net.launchpad.backintime.UdevRuleSave		auth_admin:auth_admin:auth_admin

--- a/profiles/polkit-default-privs.standard
+++ b/profiles/polkit-default-privs.standard
@@ -933,9 +933,9 @@ com.redhat.tuned.profile_info 			yes
 com.redhat.tuned.profiles			yes
 com.redhat.tuned.profiles2 			yes
 com.redhat.tuned.recommend_profile 		yes
-com.redhat.tuned.reload				auth_admin:auth_admin:yes
-com.redhat.tuned.start				auth_admin:auth_admin:yes
-com.redhat.tuned.stop				auth_admin:auth_admin:yes
+com.redhat.tuned.reload				auth_admin:auth_admin:auth_admin
+com.redhat.tuned.start				auth_admin:auth_admin:auth_admin
+com.redhat.tuned.stop				auth_admin:auth_admin:auth_admin
 com.redhat.tuned.switch_profile			auth_admin:auth_admin:yes
 # tuned (bsc#1048961)
 com.redhat.tuned.verify_profile			yes:yes:yes
@@ -953,7 +953,7 @@ com.redhat.tuned.get_plugin_hints               auth_admin:auth_self:yes
 # incremental addition (bsc#1185418)
 com.redhat.tuned.post_loaded_profile            yes:yes:yes
 # addition of acquire_devices method (bsc#1208727)
-com.redhat.tuned.instance_acquire_devices       auth_admin:auth_admin:yes
+com.redhat.tuned.instance_acquire_devices       auth_admin:auth_admin:auth_admin
 # additional getter methods (bsc#1220081)
 com.redhat.tuned.get_instances                  yes:yes:yes
 com.redhat.tuned.instance_get_devices           yes:yes:yes

--- a/profiles/polkit-default-privs.standard
+++ b/profiles/polkit-default-privs.standard
@@ -957,6 +957,11 @@ com.redhat.tuned.instance_acquire_devices       auth_admin:auth_admin:yes
 # additional getter methods (bsc#1220081)
 com.redhat.tuned.get_instances                  yes:yes:yes
 com.redhat.tuned.instance_get_devices           yes:yes:yes
+# additional instance create/destroy and PPD methods (bsc#1232412)
+com.redhat.tuned.instance_create                auth_admin:auth_admin:auth_admin
+com.redhat.tuned.instance_destroy               auth_admin:auth_admin:auth_admin
+net.hadess.PowerProfiles.HoldProfile            no:no:yes
+net.hadess.PowerProfiles.ReleaseProfile         no:no:yes
 
 # backintime (bsc#1007723)
 net.launchpad.backintime.UdevRuleSave		auth_admin:auth_admin:auth_admin

--- a/profiles/polkit-default-privs.standard
+++ b/profiles/polkit-default-privs.standard
@@ -926,7 +926,6 @@ org.blueman.pppd.pppconnect			auth_admin:auth_admin_keep:yes
 org.blueman.rfkill.setstate			auth_admin:auth_admin_keep:yes
 
 # tuned (bsc#1007279)
-com.redhat.tuned.gui.run			auth_admin
 com.redhat.tuned.active_profile			yes
 com.redhat.tuned.disable			auth_admin:auth_admin:yes
 com.redhat.tuned.is_running			yes


### PR DESCRIPTION
Original commits on master:

2768690e861caff8a5f33db42ea4c1ca1de9e3d4 drop dead gui.run
324334895ab41d43a81455714c2dd91f61747ac5 post_loaded_profile
8b16780de20984823e9d8c6bc08ee77f84942873 acquire_devices
5b3c5f77b70cf9d61b164542171db0ceb0256867 get_instances, get_devices
b2a348f7856cd4fe6fcade5fecfad9cfe28f0437 instance_created, HoldProfile
ed3f62581d56a122b4b17bdbf7aaa1798fd59585 adjusted settings
b03f33d1eac6dc333338fd4f3608e3e207502e6e tuned-ppd renames and minor changes

I tried actual cherry-picks this time, despite `git` not being able to follow renames.