### PR TITLE
profiles: whitelist timekpr-next (bsc#1234134)

### DIFF
--- a/profiles/easy
+++ b/profiles/easy
@@ -843,3 +843,6 @@ org.rpm.dnf.v0.base.Config.override auth_admin:auth_admin:auth_admin
 #  system wide RDP daemon for display manager access (bsc#1222159)
 org.gnome.remotedesktop.configure-system-daemon auth_admin:auth_admin:auth_admin_keep
 org.gnome.remotedesktop.enable-system-daemon auth_admin:auth_admin:auth_admin_keep
+
+# timekpr-next admin interface (bsc#1234134)
+com.ubuntu.timekpr.pkexec auth_admin:auth_admin:auth_admin

--- a/profiles/restrictive
+++ b/profiles/restrictive
@@ -844,3 +844,6 @@ org.rpm.dnf.v0.base.Config.override auth_admin:auth_admin:auth_admin
 #  system wide RDP daemon for display manager access (bsc#1222159)
 org.gnome.remotedesktop.configure-system-daemon auth_admin:auth_admin:auth_admin
 org.gnome.remotedesktop.enable-system-daemon auth_admin:auth_admin:auth_admin
+
+# timekpr-next admin interface (bsc#1234134)
+com.ubuntu.timekpr.pkexec auth_admin:auth_admin:auth_admin

--- a/profiles/standard
+++ b/profiles/standard
@@ -844,3 +844,6 @@ org.rpm.dnf.v0.base.Config.override auth_admin:auth_admin:auth_admin
 #  system wide RDP daemon for display manager access (bsc#1222159)
 org.gnome.remotedesktop.configure-system-daemon auth_admin:auth_admin:auth_admin_keep
 org.gnome.remotedesktop.enable-system-daemon auth_admin:auth_admin:auth_admin_keep
+
+# timekpr-next admin interface (bsc#1234134)
+com.ubuntu.timekpr.pkexec auth_admin:auth_admin:auth_admin


### PR DESCRIPTION
pkexec is required for the administrative user interface.
https://bugzilla.opensuse.org/show_bug.cgi?id=1234134