### PR TITLE
profiles: additional backports for tuned (bsc#1236029)

### DIFF
--- a/profiles/polkit-default-privs.easy
+++ b/profiles/polkit-default-privs.easy
@@ -966,6 +966,9 @@ net.hadess.PowerProfiles.switch-profile         no:no:yes
 # this action is currently only found in tuned-ppd.
 # once upower-daemon implements it, this should be moved into the UPower section
 org.freedesktop.UPower.PowerProfiles.release-profile no:no:yes
+# additional upower actions covered by tuned that are whitelisted for upower in Factory already
+org.freedesktop.UPower.PowerProfiles.switch-profile auth_admin:yes:yes
+org.freedesktop.UPower.PowerProfiles.hold-profile auth_admin:yes:yes
 
 # backintime (bsc#1007723)
 net.launchpad.backintime.UdevRuleSave		auth_admin:auth_admin:auth_admin

--- a/profiles/polkit-default-privs.restrictive
+++ b/profiles/polkit-default-privs.restrictive
@@ -908,6 +908,9 @@ net.hadess.PowerProfiles.switch-profile         no:no:yes
 # this action is currently only found in tuned-ppd.
 # once upower-daemon implements it, this should be moved into the UPower section
 org.freedesktop.UPower.PowerProfiles.release-profile no:no:yes
+# additional upower actions covered by tuned that are whitelisted for upower in Factory already
+org.freedesktop.UPower.PowerProfiles.switch-profile no:no:yes
+org.freedesktop.UPower.PowerProfiles.hold-profile no:no:yes
 
 # backintime (bsc#1007723)
 net.launchpad.backintime.UdevRuleSave		auth_admin:auth_admin:auth_admin

--- a/profiles/polkit-default-privs.standard
+++ b/profiles/polkit-default-privs.standard
@@ -968,6 +968,9 @@ net.hadess.PowerProfiles.switch-profile         no:no:yes
 # this action is currently only found in tuned-ppd.
 # once upower-daemon implements it, this should be moved into the UPower section
 org.freedesktop.UPower.PowerProfiles.release-profile no:no:yes
+# additional upower actions covered by tuned that are whitelisted for upower in Factory already
+org.freedesktop.UPower.PowerProfiles.switch-profile no:no:yes
+org.freedesktop.UPower.PowerProfiles.hold-profile no:no:yes
 
 # backintime (bsc#1007723)
 net.launchpad.backintime.UdevRuleSave		auth_admin:auth_admin:auth_admin


### PR DESCRIPTION
In Factory these actions are covered by upowerd already, but in SLE-15-SP7 these don't exist yet. tuned provides drop-in replacements for them.

These are manual backports, because otherwise we'd need multiple cherry-picks that would give use more than what we actually need here.