### PR TITLE
profiles: add ModemManager CellBroadcast action (bsc#1243684)

### DIFF
--- a/profiles/easy
+++ b/profiles/easy
@@ -394,6 +394,8 @@ org.freedesktop.ModemManager1.USSD                              auth_admin:auth_
 org.freedesktop.ModemManager1.Voice                             auth_admin:auth_self_keep:yes
 # bsc#1156961
 org.freedesktop.ModemManager1.Time                              no:no:auth_self_keep
+# bsc#1243684
+org.freedesktop.ModemManager1.CellBroadcast                     no:no:yes
 
 # urfkill (bsc#688328)
 org.freedesktop.urfkill.block                                   auth_admin:auth_self:yes

--- a/profiles/restrictive
+++ b/profiles/restrictive
@@ -395,6 +395,8 @@ org.freedesktop.ModemManager1.USSD                              no:no:auth_self_
 org.freedesktop.ModemManager1.Voice                             no:no:auth_admin_keep
 # bsc#1156961
 org.freedesktop.ModemManager1.Time                              no:no:auth_self_keep
+# bsc#1243684
+org.freedesktop.ModemManager1.CellBroadcast                     no:no:auth_self_keep
 
 # urfkill (bsc#688328)
 org.freedesktop.urfkill.block                                   no:no:auth_admin

--- a/profiles/standard
+++ b/profiles/standard
@@ -395,6 +395,8 @@ org.freedesktop.ModemManager1.USSD                              no:no:yes
 org.freedesktop.ModemManager1.Voice                             no:no:yes
 # bsc#1156961
 org.freedesktop.ModemManager1.Time                              no:no:auth_self_keep
+# bsc#1243684
+org.freedesktop.ModemManager1.CellBroadcast                     no:no:yes
 
 # urfkill (bsc#688328)
 org.freedesktop.urfkill.block                                   no:auth_admin:yes


### PR DESCRIPTION
For the restrictive profile follow the current approach and tighten to `auth_self_keep`. The action is only about deleting cell broadcast messages, not a very sensitive privilege.