### PR TITLE
profiles: whitelist kio-admin (bsc#1229913)

### DIFF
--- a/profiles/easy
+++ b/profiles/easy
@@ -198,6 +198,8 @@ org.kde.kded.inotify.increasewatchlimit                         no:no:auth_admin
 org.kde.drkonqi.saveCoreToFile                                  no:no:auth_admin_keep
 # kdeplasma-addons-kameleon (bsc#1226306)
 org.kde.kameleonhelper.writecolor                               no:yes:yes
+# privileged file operations in KDE used e.g. in Dolphin (bsc#1229913)
+org.kde.kio.admin.commands                                      no:no:auth_admin_keep
 
 # systemd (bsc#641924)
 org.freedesktop.hostname1.set-hostname                          auth_admin

--- a/profiles/restrictive
+++ b/profiles/restrictive
@@ -199,6 +199,8 @@ org.kde.kded.inotify.increasewatchlimit                         no:no:auth_admin
 org.kde.drkonqi.saveCoreToFile                                  no:no:auth_admin
 # kdeplasma-addons-kameleon (bsc#1226306)
 org.kde.kameleonhelper.writecolor                               no:no:yes
+# privileged file operations in KDE used e.g. in Dolphin (bsc#1229913)
+org.kde.kio.admin.commands                                      no:no:auth_admin_keep
 
 # systemd (bsc#641924)
 org.freedesktop.hostname1.set-hostname                          auth_admin

--- a/profiles/standard
+++ b/profiles/standard
@@ -199,6 +199,8 @@ org.kde.kded.inotify.increasewatchlimit                         no:no:auth_admin
 org.kde.drkonqi.saveCoreToFile                                  no:no:auth_admin
 # kdeplasma-addons-kameleon (bsc#1226306)
 org.kde.kameleonhelper.writecolor                               no:yes:yes
+# privileged file operations in KDE used e.g. in Dolphin (bsc#1229913)
+org.kde.kio.admin.commands                                      no:no:auth_admin_keep
 
 # systemd (bsc#641924)
 org.freedesktop.hostname1.set-hostname                          auth_admin


### PR DESCRIPTION
There is a request to add this to Leap 16.0:

https://build.opensuse.org/request/show/1271698

Whitelisting needs to go to SLFO:Main for this.
