### PR TITLE
profiles: whitelist Foomuuri actions (bsc#1254385)

### DIFF
--- a/profiles/easy
+++ b/profiles/easy
@@ -904,3 +904,7 @@ io.snapcraft.snapd.manage auth_admin:auth_admin:auth_admin_keep
 io.snapcraft.snapd.manage-interfaces auth_admin:auth_admin:auth_admin_keep
 io.snapcraft.snapd.manage-configuration auth_admin:auth_admin:auth_admin_keep
 io.snapcraft.snapd.manage-fde auth_admin:auth_admin:auth_admin_keep
+
+# Foomuuri firewall manager (bsc#1254385)
+fi.foobar.Foomuuri1.info yes:yes:yes
+fi.foobar.Foomuuri1.config auth_admin_keep:auth_admin_keep:auth_admin_keep

--- a/profiles/restrictive
+++ b/profiles/restrictive
@@ -905,3 +905,7 @@ io.snapcraft.snapd.manage auth_admin:auth_admin:auth_admin_keep
 io.snapcraft.snapd.manage-interfaces auth_admin:auth_admin:auth_admin_keep
 io.snapcraft.snapd.manage-configuration auth_admin:auth_admin:auth_admin_keep
 io.snapcraft.snapd.manage-fde auth_admin:auth_admin:auth_admin_keep
+
+# Foomuuri firewall manager (bsc#1254385)
+fi.foobar.Foomuuri1.info auth_admin:auth_admin:yes
+fi.foobar.Foomuuri1.config no:auth_admin:auth_admin

--- a/profiles/standard
+++ b/profiles/standard
@@ -905,3 +905,7 @@ io.snapcraft.snapd.manage auth_admin:auth_admin:auth_admin_keep
 io.snapcraft.snapd.manage-interfaces auth_admin:auth_admin:auth_admin_keep
 io.snapcraft.snapd.manage-configuration auth_admin:auth_admin:auth_admin_keep
 io.snapcraft.snapd.manage-fde auth_admin:auth_admin:auth_admin_keep
+
+# Foomuuri firewall manager (bsc#1254385)
+fi.foobar.Foomuuri1.info yes:yes:yes
+fi.foobar.Foomuuri1.config auth_admin_keep:auth_admin_keep:auth_admin_keep


### PR DESCRIPTION
For the restrictive profile I went for some hardening here. `info` requires auth_admin for random and inactive users there. `config` is disallowed for random users and does not keep authentication for active/inactive users.

The package for this is currently found on OBS in home:UbiquitousPhoton/Foomuuri.