### PR TITLE
add GDM manage-user-displays action (bsc#1258025)

### DIFF
--- a/profiles/easy
+++ b/profiles/easy
@@ -1010,3 +1010,6 @@ org.shadowblip.Output.ForceFeedback.Rumble no:auth_admin:auth_admin
 org.shadowblip.Output.ForceFeedback.Stop no:auth_admin:auth_admin
 org.shadowblip.Input.Metrics.Enabled no:auth_admin:auth_admin
 org.shadowblip.Input.Metrics.SetEnabled no:auth_admin:auth_admin
+
+# gdm (bsc#1258025)
+org.gnome.displaymanager.displayfactory.manage-user-displays auth_admin:auth_admin:auth_admin_keep

--- a/profiles/restrictive
+++ b/profiles/restrictive
@@ -1011,3 +1011,6 @@ org.shadowblip.Output.ForceFeedback.Rumble no:auth_admin:auth_admin
 org.shadowblip.Output.ForceFeedback.Stop no:auth_admin:auth_admin
 org.shadowblip.Input.Metrics.Enabled no:auth_admin:auth_admin
 org.shadowblip.Input.Metrics.SetEnabled no:auth_admin:auth_admin
+
+# gdm (bsc#1258025)
+org.gnome.displaymanager.displayfactory.manage-user-displays auth_admin:auth_admin:auth_admin

--- a/profiles/standard
+++ b/profiles/standard
@@ -1011,3 +1011,6 @@ org.shadowblip.Output.ForceFeedback.Rumble no:auth_admin:auth_admin
 org.shadowblip.Output.ForceFeedback.Stop no:auth_admin:auth_admin
 org.shadowblip.Input.Metrics.Enabled no:auth_admin:auth_admin
 org.shadowblip.Input.Metrics.SetEnabled no:auth_admin:auth_admin
+
+# gdm (bsc#1258025)
+org.gnome.displaymanager.displayfactory.manage-user-displays auth_admin:auth_admin:auth_admin


### PR DESCRIPTION
The package with this action can be found in OBS in GNOME:Next/gdm.