### PR TITLE
profiles: systemd v260 follow-up (bsc#1259318)

### DIFF
--- a/profiles/easy
+++ b/profiles/easy
@@ -366,6 +366,8 @@ io.systemd.ask-password.ask                                      auth_admin_keep
 # new action in v260 sysext (bsc#1259318)
 io.systemd.sysext.manage                                         auth_admin:auth_admin:auth_admin_keep
 io.systemd.confext.manage                                        auth_admin:auth_admin:auth_admin_keep
+io.systemd.sysext.read                                           yes:yes:yes
+io.systemd.confext.read                                          yes:yes:yes
 # new action in v260 networkd (bsc#1259318)
 org.freedesktop.network1.manage-links                            auth_admin:auth_admin:auth_admin_keep
 

--- a/profiles/restrictive
+++ b/profiles/restrictive
@@ -367,6 +367,8 @@ io.systemd.ask-password.ask                                      auth_admin_keep
 # new action in v260 sysext (bsc#1259318)
 io.systemd.sysext.manage                                         auth_admin:auth_admin:auth_admin_keep
 io.systemd.confext.manage                                        auth_admin:auth_admin:auth_admin_keep
+io.systemd.sysext.read                                           yes:yes:yes
+io.systemd.confext.read                                          yes:yes:yes
 # new action in v260 networkd (bsc#1259318)
 org.freedesktop.network1.manage-links                            auth_admin:auth_admin:auth_admin_keep
 

--- a/profiles/standard
+++ b/profiles/standard
@@ -367,6 +367,8 @@ io.systemd.ask-password.ask                                      auth_admin_keep
 # new action in v260 sysext (bsc#1259318)
 io.systemd.sysext.manage                                         auth_admin:auth_admin:auth_admin_keep
 io.systemd.confext.manage                                        auth_admin:auth_admin:auth_admin_keep
+io.systemd.sysext.read                                           yes:yes:yes
+io.systemd.confext.read                                          yes:yes:yes
 # new action in v260 networkd (bsc#1259318)
 org.freedesktop.network1.manage-links                            auth_admin:auth_admin:auth_admin_keep
 


### PR DESCRIPTION
Two additional methods were missed in the first whitelisting:

- io.systemd.sysext.read
- io.systemd.confext.read