### PR TITLE
profiles: fwupd new actions in 2.1.4 (bsc#1267014)

### DIFF
--- a/profiles/easy
+++ b/profiles/easy
@@ -732,6 +732,14 @@ org.freedesktop.fwupd.emulation-tag                             auth_admin:auth_
 org.freedesktop.fwupd.emulation-load                            auth_admin:auth_admin:auth_admin_keep
 # fwupd (bsc#1253111)
 org.freedesktop.fwupd.clean-remote                              auth_admin:no:auth_admin_keep
+# fwupd (bsc#1267014)
+org.freedesktop.fwupd.modify-device                             auth_admin:no:yes
+org.freedesktop.fwupd.clear-results                             auth_admin:no:yes
+org.freedesktop.fwupd.verify                                    auth_admin:no:yes
+org.freedesktop.fwupd.get-remotes                               auth_admin:no:yes
+org.freedesktop.fwupd.refresh-remote                            auth_admin:no:yes
+org.freedesktop.fwupd.enable-remote                             auth_admin:no:auth_admin_keep
+org.freedesktop.fwupd.device-emulate                            auth_admin:no:auth_admin
 
 # connman (bsc#1057697)
 net.connman.modify                                              auth_admin_keep

--- a/profiles/restrictive
+++ b/profiles/restrictive
@@ -733,6 +733,14 @@ org.freedesktop.fwupd.emulation-tag                             auth_admin:no:au
 org.freedesktop.fwupd.emulation-load                            auth_admin:no:auth_admin_keep
 # fwupd (bsc#1253111)
 org.freedesktop.fwupd.clean-remote                              auth_admin:no:auth_admin_keep
+# fwupd (bsc#1267014)
+org.freedesktop.fwupd.modify-device                             auth_admin:no:auth_admin_keep
+org.freedesktop.fwupd.clear-results                             auth_admin:no:auth_admin_keep
+org.freedesktop.fwupd.verify                                    auth_admin:no:auth_admin_keep
+org.freedesktop.fwupd.get-remotes                               auth_admin:no:auth_admin_keep
+org.freedesktop.fwupd.refresh-remote                            auth_admin:no:auth_admin_keep
+org.freedesktop.fwupd.enable-remote                             auth_admin:no:auth_admin_keep
+org.freedesktop.fwupd.device-emulate                            auth_admin:no:auth_admin
 
 # connman (bsc#1057697)
 net.connman.modify                                              auth_admin_keep

--- a/profiles/standard
+++ b/profiles/standard
@@ -733,6 +733,14 @@ org.freedesktop.fwupd.emulation-tag                             auth_admin:no:au
 org.freedesktop.fwupd.emulation-load                            auth_admin:no:auth_admin_keep
 # fwupd (bsc#1253111)
 org.freedesktop.fwupd.clean-remote                              auth_admin:no:auth_admin_keep
+# fwupd (bsc#1267014)
+org.freedesktop.fwupd.modify-device                             auth_admin:no:yes
+org.freedesktop.fwupd.clear-results                             auth_admin:no:yes
+org.freedesktop.fwupd.verify                                    auth_admin:no:yes
+org.freedesktop.fwupd.get-remotes                               auth_admin:no:yes
+org.freedesktop.fwupd.refresh-remote                            auth_admin:no:yes
+org.freedesktop.fwupd.enable-remote                             auth_admin:no:auth_admin_keep
+org.freedesktop.fwupd.device-emulate                            auth_admin:no:auth_admin
 
 # connman (bsc#1057697)
 net.connman.modify                                              auth_admin_keep


### PR DESCRIPTION
Defaults were taken verbatim from upstream, except in the restrictive profile (s/yes/auth_admin_keep/).